### PR TITLE
 ### Version 0.5.7 (2025-1-23)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ ffmpy.egg-info/*
 *.mp4
 *.mkv
 *.yuv
+*.mov
 #s/dist
 #/build
 runTests.yaml

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 
 The name **CeLux** is derived from the Latin words `celer` (speed) and `lux` (light), reflecting its commitment to speed and efficiency.
 
+# [Check out the latest changes](docs/CHANGELOG.md#version-057)
+
 ## 📚 Documentation
 
 - [📝 Changelog](docs/CHANGELOG.md)
@@ -28,7 +30,6 @@ The name **CeLux** is derived from the Latin words `celer` (speed) and `lux` (li
 
 - **⚡ Ultra-Fast Video Decoding:** Achieve lightning-fast decode times for full HD videos using hardware acceleration.
 - **🔗 Direct Decoding to Tensors:** Decode video frames directly into PyTorch tensors for immediate processing.
-- **🖥️ Hardware Acceleration Support:** Utilize CUDA for GPU-accelerated decoding, significantly improving performance.
 - **🔄 Easy Integration:** Seamlessly integrates with existing Python workflows, making it easy to incorporate into your projects.
 
 ## ⚡ Quick Start
@@ -36,9 +37,7 @@ The name **CeLux** is derived from the Latin words `celer` (speed) and `lux` (li
 ```sh
 pip install celux  # cpu only version
 ```
-```sh
-pip install celux-cuda  # cuda+cpu
-```
+
 ```py
 from celux import VideoReader, Scale
 #import celux as cx
@@ -59,7 +58,6 @@ for frame in reader:
 | Library  | Device       | Frames per Second (FPS) |
 |----------|--------------|-------------------------|
 | Celux | CPU      | 1520.75                 |
-| Celux | CUDA      | 1710.85                |
 | PyAV | CPU      | 350.58                |
 | OpenCV | CPU      | 454.44                 |
 

--- a/build.py
+++ b/build.py
@@ -3,7 +3,7 @@ import subprocess
 import shutil
 
 # Hardcoded version for both CPU and CUDA builds
-VERSION = "0.5.6.1"
+VERSION = "0.5.7"
 
 def build_package(is_cuda=False):
     """

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,23 @@
 ## 📈 Changelog
 
+### Version 0.5.7 (2025-1-23)
+
+- **New color format support**  
+  Added CPU-based conversions for:
+  - 12-bit YUV (420, 422, and 444)
+  - 10-bit YUV444
+  - ProRes 4444 with alpha (10-bit or 12-bit)
+  - Anything NOT 8-bit uses `uint-16` tensors.
+  
+- **Notes on rawvideo**  
+  Raw `.yuv` files still require specifying resolution and pixel format manually.  
+  (`-f rawvideo -pix_fmt yuv420p -s 1920x1080 …`)  
+  - **IN PROGRESS****
+
+- **Other improvements**  
+  - Minor cleanups in converter classes.
+  - Updated tests to cover the newly supported pixel formats.
+
 ### Version 0.5.6.1 (2025-1-23)
   = Adusted `__call__` method handling.
     - `Int` values seek as frames, `Float` values seek as times.

--- a/docs/GETTINGSTARTED.md
+++ b/docs/GETTINGSTARTED.md
@@ -12,12 +12,8 @@ def process_frame(frame):
     # Implement your frame processing logic here
     pass
 
-# Choose device based on your installation
-device = "cuda" if torch.cuda.is_available() else "cpu"
-
 with cx.VideoReader(
     "path/to/input/video.mp4",
-    device=device     # "cpu" or "cuda"
 ) as reader:
     for frame in reader:
         # Frame is a PyTorch tensor in HWC format
@@ -37,7 +33,6 @@ with cx.VideoReader(
 ```python
 reader = cx.VideoReader(
     "path/to/video.mp4",
-    device="cuda",        # Use "cpu" or "cuda"
 )
 ```
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -3,10 +3,9 @@
  
 ### 🤖 PIP installation
 
-**CeLux** offers two installation options tailored to your system's capabilities:
+**CeLux** offers one installation options tailored to your system's capabilities:
 
 1. **CPU-Only Version:** For systems without CUDA-capable GPUs.
-2. **CUDA (GPU) Version:** For systems with NVIDIA GPUs supporting CUDA.
 
 ### 🖥️ CPU-Only Installation
 
@@ -16,27 +15,9 @@ Install the CPU version of **CeLux** using `pip`:
 pip install celux
 ```
 
-**Note:** The CPU version **only** supports CPU operations. Attempting to use GPU features with this version will result in an error.
-
-### 🖥️ CUDA (GPU) Installation
-
-Install the CUDA version of **CeLux** using `pip`:
-
-```bash
-pip install celux-cuda
-```
-
-**Note:** The CUDA version **requires** a CUDA-capable GPU and the corresponding Torch-Cuda installation.
-
-### 🔄 Both Packages Import as `celux`
-
-Regardless of the installation choice, both packages are imported using the same module name:
-
 ```python
 import celux #as cx
 ```
-
-This design ensures a seamless transition between CPU and CUDA versions without changing your import statements.
 
 ## 🛠️ Building from Source
 

--- a/include/CeLux/Factory.hpp
+++ b/include/CeLux/Factory.hpp
@@ -34,15 +34,14 @@ class Factory
      * @param converter Unique pointer to the IConverter instance.
      * @return std::unique_ptr<Decoder> Pointer to the created Decoder.
      */
-    static std::unique_ptr<Decoder> createDecoder(torch::Device device, const std::string& filename, int numThreads,
+    static std::unique_ptr<Decoder>
+    createDecoder(torch::Device device, const std::string& filename, int numThreads,
                   std::vector<std::shared_ptr<FilterBase>> filters)
     {
 
-            return std::make_unique<celux::backends::cpu::Decoder>(filename, numThreads,
-                                                                   filters);
-      
+        return std::make_unique<celux::backends::cpu::Decoder>(filename, numThreads,
+                                                               filters);
     }
-
 
     /**
      * @brief Creates a Converter instance based on the specified backend and pixel
@@ -69,13 +68,14 @@ class Factory
         // Define the key based on device and pixel format
         ConverterKey key = std::make_tuple(is_cpu, pixfmt);
 
-        // Define the factory map
+        // Define the factory map (CPU only in this example)
         static const std::unordered_map<ConverterKey,
-                                        std::function<std::unique_ptr<IConverter>(
-                                            )>,
+                                        std::function<std::unique_ptr<IConverter>()>,
                                         ConverterKeyHash>
             converterMap = {
-                // CPU converters
+                // -------------------------------------------------------
+                // Existing CPU converters
+                // -------------------------------------------------------
                 {std::make_tuple(true, AV_PIX_FMT_YUV420P),
                  []() -> std::unique_ptr<IConverter>
                  {
@@ -90,11 +90,11 @@ class Factory
                      return std::make_unique<cpu::YUV420P10ToRGB48>();
                  }},
                 {std::make_tuple(true, AV_PIX_FMT_YUV422P10LE),
-				 []() -> std::unique_ptr<IConverter>
-				 {
-					 CELUX_DEBUG("Creating YUV422P10LEToRGB48 converter");
-					 return std::make_unique<cpu::YUV422P10ToRGB48>();
-				 }},
+                 []() -> std::unique_ptr<IConverter>
+                 {
+                     CELUX_DEBUG("Creating YUV422P10LEToRGB48 converter");
+                     return std::make_unique<cpu::YUV422P10ToRGB48>();
+                 }},
 
                 // bgr24
                 {std::make_tuple(true, AV_PIX_FMT_BGR24),
@@ -103,14 +103,14 @@ class Factory
                      CELUX_DEBUG("Creating BGR24ToRGB converter");
                      return std::make_unique<cpu::BGRToRGB>();
                  }},
-                //rgb24
+                // rgb24
                 {std::make_tuple(true, AV_PIX_FMT_RGB24),
-                         []() -> std::unique_ptr<IConverter>
-                         {
-					 CELUX_DEBUG("Creating RGB24ToRGB converter");
-					 return std::make_unique<cpu::RGBToRGB>();
-				 }},
-                // New CPU converters with alpha channels
+                 []() -> std::unique_ptr<IConverter>
+                 {
+                     CELUX_DEBUG("Creating RGB24ToRGB converter");
+                     return std::make_unique<cpu::RGBToRGB>();
+                 }},
+                // RGBA, BGRA, GBRP, etc.
                 {std::make_tuple(true, AV_PIX_FMT_RGBA),
                  []() -> std::unique_ptr<IConverter>
                  {
@@ -124,27 +124,81 @@ class Factory
                      return std::make_unique<cpu::BGRAToRGB>();
                  }},
                 {std::make_tuple(true, AV_PIX_FMT_GBRP),
-				 []() -> std::unique_ptr<IConverter>
-				 {
-					 CELUX_DEBUG("Creating GBRPToRGB converter");
-					 return std::make_unique<cpu::GBRPToRGB>();
-				 }},
-                
+                 []() -> std::unique_ptr<IConverter>
+                 {
+                     CELUX_DEBUG("Creating GBRPToRGB converter");
+                     return std::make_unique<cpu::GBRPToRGB>();
+                 }},
+
+                // 8-bit YUV422
+                {std::make_tuple(true, AV_PIX_FMT_YUV422P),
+                 []() -> std::unique_ptr<IConverter>
+                 {
+                     CELUX_DEBUG("Creating YUV422P8ToRGB24 converter");
+                     return std::make_unique<cpu::YUV422P8ToRGB24>();
+                 }},
+
+                // 8-bit YUV444
+                {std::make_tuple(true, AV_PIX_FMT_YUV444P),
+                 []() -> std::unique_ptr<IConverter>
+                 {
+                     CELUX_DEBUG("Creating YUV444P8ToRGB24 converter");
+                     return std::make_unique<cpu::YUV444P8ToRGB24>();
+                 }},
+
+                // -------------------------------------------------------
+                // NEW ENTRIES FOR 10/12-BIT and PRORES4444
+                // -------------------------------------------------------
+
+                // 10-bit YUV444
+                {std::make_tuple(true, AV_PIX_FMT_YUV444P10LE),
+                 []() -> std::unique_ptr<IConverter>
+                 {
+                     CELUX_DEBUG("Creating YUV444P10LEToRGB48 converter");
+                     return std::make_unique<cpu::YUV444P10ToRGB48>();
+                 }},
+
+                // 12-bit YUV420
+                {std::make_tuple(true, AV_PIX_FMT_YUV420P12LE),
+                 []() -> std::unique_ptr<IConverter>
+                 {
+                     CELUX_DEBUG("Creating YUV420P12ToRGB48 converter");
+                     return std::make_unique<cpu::YUV420P12ToRGB48>();
+                 }},
+
+                // 12-bit YUV422
+                {std::make_tuple(true, AV_PIX_FMT_YUV422P12LE),
+                 []() -> std::unique_ptr<IConverter>
+                 {
+                     CELUX_DEBUG("Creating YUV422P12ToRGB48 converter");
+                     return std::make_unique<cpu::YUV422P12ToRGB48>();
+                 }},
+
+                // 12-bit YUV444
+                {std::make_tuple(true, AV_PIX_FMT_YUV444P12LE),
+                 []() -> std::unique_ptr<IConverter>
+                 {
+                     CELUX_DEBUG("Creating YUV444P12ToRGB48 converter");
+                     return std::make_unique<cpu::YUV444P12ToRGB48>();
+                 }},
+
+             
             };
 
-        // Search for the converter in the map
+        // Look up the converter in the map
         auto it = converterMap.find(key);
         if (it != converterMap.end())
         {
             return it->second();
         }
 
-        // If not found, throw an exception with detailed information
+        // If no match, throw
         std::string deviceType = is_cpu ? "CPU" : (is_cuda ? "CUDA" : "Unknown");
         throw std::invalid_argument("Unsupported combination - Device: " + deviceType +
                                     ", Bit Depth: " + std::to_string(bit_depth) +
                                     ", Pixel Format: " + av_get_pix_fmt_name(pixfmt));
     }
+
 
   private:
     // Helper function to infer bit depth from AVPixelFormat
@@ -152,6 +206,7 @@ class Factory
     {
         switch (pixfmt)
         {
+        // Already existing 8-bit formats
         case AV_PIX_FMT_YUV420P:
         case AV_PIX_FMT_RGB24:
         case AV_PIX_FMT_NV12:
@@ -160,12 +215,49 @@ class Factory
         case AV_PIX_FMT_BGRA:
         case AV_PIX_FMT_GBRP:
             return 8;
+
+        // Already existing 10-bit formats
         case AV_PIX_FMT_YUV420P10LE:
         case AV_PIX_FMT_YUV422P10LE:
         case AV_PIX_FMT_P010LE:
         case AV_PIX_FMT_RGB48LE:
             return 10;
-        // Add more cases as needed
+
+        // ------------------------
+        // NEW ENTRIES (one by one)
+        // ------------------------
+        // 8-bit planar 4:2:2
+        case AV_PIX_FMT_YUV422P:
+            return 8;
+
+        // 8-bit planar 4:4:4
+        case AV_PIX_FMT_YUV444P:
+            return 8;
+
+        // 10-bit planar 4:4:4
+        case AV_PIX_FMT_YUV444P10LE:
+            return 10;
+
+        // 12-bit planar 4:2:0
+        case AV_PIX_FMT_YUV420P12LE:
+            return 12;
+
+        // 12-bit planar 4:2:2
+        case AV_PIX_FMT_YUV422P12LE:
+            return 12;
+
+        // 12-bit planar 4:4:4
+        case AV_PIX_FMT_YUV444P12LE:
+            return 12;
+
+        // ProRes4444 often decodes to YUVA444P10 or YUVA444P16.
+        // If you know specifically it's 10-bit:
+        case AV_PIX_FMT_YUVA444P10LE:
+            return 10;
+        // Or if you also want to handle 12-bit alpha:
+        case AV_PIX_FMT_YUVA444P12LE:
+            return 12;
+
         default:
             throw std::invalid_argument(
                 std::string("Unknown pixel format for bit depth inference: ") +

--- a/include/CeLux/backends/Decoder.hpp
+++ b/include/CeLux/backends/Decoder.hpp
@@ -45,7 +45,7 @@ class Decoder
     void addFilter(const std::unique_ptr<FilterBase>& filter);
     Decoder(Decoder&&) noexcept;
     Decoder& operator=(Decoder&&) noexcept;
-
+    bool seekFrame(int frameIndex);
     virtual bool decodeNextFrame(void* buffer, double* frame_timestamp = nullptr);
     virtual bool seek(double timestamp);
     virtual VideoProperties getVideoProperties() const;

--- a/include/CeLux/conversion/cpu/CPUConverters.hpp
+++ b/include/CeLux/conversion/cpu/CPUConverters.hpp
@@ -2,14 +2,37 @@
 #ifndef CPU_CONVERTERS_HPP
 #define CPU_CONVERTERS_HPP
 
-#include <cpu/CPUConverter.hpp>
-#include <cpu/YUV420PToRGB.hpp>
-#include <cpu/YUV420P10ToRGB48.hpp>
-#include <cpu/YUV422P10ToRGB48.hpp>
-#include <cpu/BGRToRGB.hpp>
-#include <cpu/RGBToRGB.hpp>
-#include <cpu/RGBAToRGB.hpp>
+// Base classes and existing converters
 #include <cpu/BGRAToRGB.hpp>
+#include <cpu/BGRToRGB.hpp>
+#include <cpu/CPUConverter.hpp>
 #include <cpu/GBRPToRGB.hpp>
+#include <cpu/RGBAToRGB.hpp>
+#include <cpu/RGBToRGB.hpp>
+#include <cpu/YUV420P10ToRGB48.hpp>
+#include <cpu/YUV420PToRGB.hpp>
+#include <cpu/YUV422P10ToRGB48.hpp>
+
+// -------------------------------------------------------------------------
+// New converters for additional pixel formats
+// -------------------------------------------------------------------------
+
+// 8-bit YUV422 -> RGB24
+#include <cpu/YUV422P8ToRGB24.hpp>
+
+// 12-bit YUV420 -> 48-bit RGB
+#include <cpu/YUV420P12ToRGB48.hpp>
+
+// 12-bit YUV422 -> 48-bit RGB
+#include <cpu/YUV422P12ToRGB48.hpp>
+
+// 8-bit YUV444 -> RGB24
+#include <cpu/YUV444P8ToRGB24.hpp>
+
+// 10-bit YUV444 -> 48-bit RGB
+#include <cpu/YUV444P10ToRGB48.hpp>
+
+// 12-bit YUV444 -> 48-bit RGB
+#include <cpu/YUV444P12ToRGB48.hpp>
 
 #endif // CPU_CONVERTERS_HPP

--- a/include/CeLux/conversion/cpu/YUV420P12ToRGB48.hpp
+++ b/include/CeLux/conversion/cpu/YUV420P12ToRGB48.hpp
@@ -1,0 +1,110 @@
+#pragma once
+
+#include "CPUConverter.hpp"
+
+namespace celux
+{
+namespace conversion
+{
+namespace cpu
+{
+
+/**
+ * @brief Converter for 12-bit YUV420 (YUV420P12LE) to 48-bit RGB (RGB48LE) on CPU.
+ */
+class YUV420P12ToRGB48 : public ConverterBase
+{
+  public:
+    YUV420P12ToRGB48() : ConverterBase(), swsContext(nullptr)
+    {
+    }
+    ~YUV420P12ToRGB48()
+    {
+        if (swsContext)
+        {
+            sws_freeContext(swsContext);
+            swsContext = nullptr;
+        }
+    }
+
+    void convert(celux::Frame& frame, void* buffer) override
+    {
+        // Verify the pixel format
+        if (frame.getPixelFormat() != AV_PIX_FMT_YUV420P12LE)
+        {
+            throw std::invalid_argument(
+                "Unsupported pixel format for YUV420P12ToRGB48 converter");
+        }
+
+        // Initialize swsContext if not done
+        if (!swsContext)
+        {
+            swsContext = sws_getContext(frame.getWidth(), frame.getHeight(),
+                                        AV_PIX_FMT_YUV420P12LE, // source
+                                        frame.getWidth(), frame.getHeight(),
+                                        AV_PIX_FMT_RGB48LE, // destination
+                                        SWS_BILINEAR, nullptr, nullptr, nullptr);
+
+            if (!swsContext)
+            {
+                throw std::runtime_error("Failed to initialize swsContext for "
+                                         "YUV420P12 to RGB48 conversion");
+            }
+
+            // Optionally set color space details
+            int srcRange = 0;
+            int dstRange = 1;
+            const int* srcMatrix = sws_getCoefficients(SWS_CS_DEFAULT);
+            const int* dstMatrix = sws_getCoefficients(SWS_CS_DEFAULT);
+            sws_setColorspaceDetails(swsContext, srcMatrix, srcRange, dstMatrix,
+                                     dstRange, 0, 1 << 16, 1 << 16);
+        }
+
+        // Prepare src data/linesize
+        const uint8_t* srcData[4] = {frame.getData(0), frame.getData(1),
+                                     frame.getData(2), nullptr};
+        int srcLineSize[4] = {frame.getLineSize(0), frame.getLineSize(1),
+                              frame.getLineSize(2), 0};
+
+        // Prepare dst data/linesize
+        uint8_t* dstData[4] = {nullptr};
+        int dstLineSize[4] = {0};
+        int numBytes = av_image_get_buffer_size(AV_PIX_FMT_RGB48LE, frame.getWidth(),
+                                                frame.getHeight(), 1);
+        if (numBytes < 0)
+        {
+            throw std::runtime_error("Could not get buffer size for RGB48LE");
+        }
+
+        if (!buffer)
+        {
+            throw std::invalid_argument("Destination buffer is null");
+        }
+
+        int ret = av_image_fill_arrays(
+            dstData, dstLineSize, static_cast<uint8_t*>(buffer), AV_PIX_FMT_RGB48LE,
+            frame.getWidth(), frame.getHeight(), 1 /* alignment */);
+        if (ret < 0)
+        {
+            char errBuf[256];
+            av_strerror(ret, errBuf, sizeof(errBuf));
+            throw std::runtime_error(std::string("av_image_fill_arrays failed: ") +
+                                     errBuf);
+        }
+
+        // Perform conversion
+        int result = sws_scale(swsContext, srcData, srcLineSize, 0, frame.getHeight(),
+                               dstData, dstLineSize);
+        if (result <= 0)
+        {
+            throw std::runtime_error("sws_scale failed for YUV420P12->RGB48");
+        }
+    }
+
+  private:
+    struct SwsContext* swsContext;
+};
+
+} // namespace cpu
+} // namespace conversion
+} // namespace celux

--- a/include/CeLux/conversion/cpu/YUV422P12ToRGB48.hpp
+++ b/include/CeLux/conversion/cpu/YUV422P12ToRGB48.hpp
@@ -1,0 +1,108 @@
+#pragma once
+
+#include "CPUConverter.hpp"
+
+namespace celux
+{
+namespace conversion
+{
+namespace cpu
+{
+
+/**
+ * @brief Converter for 12-bit YUV422P (YUV422P12LE) to 48-bit RGB (RGB48LE) on CPU.
+ */
+class YUV422P12ToRGB48 : public ConverterBase
+{
+  public:
+    YUV422P12ToRGB48() : ConverterBase(), swsContext(nullptr)
+    {
+    }
+    ~YUV422P12ToRGB48()
+    {
+        if (swsContext)
+        {
+            sws_freeContext(swsContext);
+            swsContext = nullptr;
+        }
+    }
+
+    void convert(celux::Frame& frame, void* buffer) override
+    {
+        // Verify pixel format
+        if (frame.getPixelFormat() != AV_PIX_FMT_YUV422P12LE)
+        {
+            throw std::invalid_argument(
+                "Unsupported pixel format for YUV422P12ToRGB48 converter");
+        }
+
+        if (!swsContext)
+        {
+            swsContext = sws_getContext(frame.getWidth(), frame.getHeight(),
+                                        AV_PIX_FMT_YUV422P12LE, // source
+                                        frame.getWidth(), frame.getHeight(),
+                                        AV_PIX_FMT_RGB48LE, // destination
+                                        SWS_BILINEAR, nullptr, nullptr, nullptr);
+
+            if (!swsContext)
+            {
+                throw std::runtime_error("Failed to initialize swsContext for "
+                                         "YUV422P12->RGB48 conversion");
+            }
+
+            // Optionally set colorspace
+            int srcRange = 0;
+            int dstRange = 1;
+            const int* srcMatrix = sws_getCoefficients(SWS_CS_DEFAULT);
+            const int* dstMatrix = sws_getCoefficients(SWS_CS_DEFAULT);
+            sws_setColorspaceDetails(swsContext, srcMatrix, srcRange, dstMatrix,
+                                     dstRange, 0, 1 << 16, 1 << 16);
+        }
+
+        // Source data
+        const uint8_t* srcData[4] = {frame.getData(0), frame.getData(1),
+                                     frame.getData(2), nullptr};
+        int srcLineSize[4] = {frame.getLineSize(0), frame.getLineSize(1),
+                              frame.getLineSize(2), 0};
+
+        // Destination data
+        uint8_t* dstData[4] = {nullptr};
+        int dstLineSize[4] = {0};
+        int numBytes = av_image_get_buffer_size(AV_PIX_FMT_RGB48LE, frame.getWidth(),
+                                                frame.getHeight(), 1);
+        if (numBytes < 0)
+        {
+            throw std::runtime_error("Could not get buffer size for RGB48LE");
+        }
+
+        if (!buffer)
+        {
+            throw std::invalid_argument("Destination buffer is null");
+        }
+
+        int ret = av_image_fill_arrays(
+            dstData, dstLineSize, static_cast<uint8_t*>(buffer), AV_PIX_FMT_RGB48LE,
+            frame.getWidth(), frame.getHeight(), 1 /* alignment */);
+        if (ret < 0)
+        {
+            char errBuf[256];
+            av_strerror(ret, errBuf, sizeof(errBuf));
+            throw std::runtime_error(std::string("av_image_fill_arrays failed: ") +
+                                     errBuf);
+        }
+
+        int result = sws_scale(swsContext, srcData, srcLineSize, 0, frame.getHeight(),
+                               dstData, dstLineSize);
+        if (result <= 0)
+        {
+            throw std::runtime_error("sws_scale failed for YUV422P12->RGB48");
+        }
+    }
+
+  private:
+    struct SwsContext* swsContext;
+};
+
+} // namespace cpu
+} // namespace conversion
+} // namespace celux

--- a/include/CeLux/conversion/cpu/YUV422P8ToRGB24.hpp
+++ b/include/CeLux/conversion/cpu/YUV422P8ToRGB24.hpp
@@ -1,0 +1,109 @@
+#pragma once
+
+#include "CPUConverter.hpp"
+
+namespace celux
+{
+namespace conversion
+{
+namespace cpu
+{
+
+/**
+ * @brief Converter for 8-bit YUV422P to 24-bit RGB (RGB24) on CPU.
+ */
+class YUV422P8ToRGB24 : public ConverterBase
+{
+  public:
+    YUV422P8ToRGB24() : ConverterBase(), swsContext(nullptr)
+    {
+    }
+    ~YUV422P8ToRGB24()
+    {
+        if (swsContext)
+        {
+            sws_freeContext(swsContext);
+            swsContext = nullptr;
+        }
+    }
+
+    void convert(celux::Frame& frame, void* buffer) override
+    {
+        // Verify the pixel format
+        if (frame.getPixelFormat() != AV_PIX_FMT_YUV422P)
+        {
+            throw std::invalid_argument(
+                "Unsupported pixel format for YUV422P8ToRGB24 converter");
+        }
+
+        // Initialize swsContext if needed
+        if (!swsContext)
+        {
+            swsContext = sws_getContext(frame.getWidth(), frame.getHeight(),
+                                        AV_PIX_FMT_YUV422P, // source
+                                        frame.getWidth(), frame.getHeight(),
+                                        AV_PIX_FMT_RGB24, // destination
+                                        SWS_BILINEAR, nullptr, nullptr, nullptr);
+
+            if (!swsContext)
+            {
+                throw std::runtime_error("Failed to initialize swsContext for "
+                                         "YUV422P->RGB24 conversion");
+            }
+
+            // Optionally set color space details
+            int srcRange = 0;
+            int dstRange = 1;
+            const int* srcMatrix = sws_getCoefficients(SWS_CS_DEFAULT);
+            const int* dstMatrix = sws_getCoefficients(SWS_CS_DEFAULT);
+            sws_setColorspaceDetails(swsContext, srcMatrix, srcRange, dstMatrix,
+                                     dstRange, 0, 1 << 16, 1 << 16);
+        }
+
+        // Prepare src data
+        const uint8_t* srcData[4] = {frame.getData(0), frame.getData(1),
+                                     frame.getData(2), nullptr};
+        int srcLineSize[4] = {frame.getLineSize(0), frame.getLineSize(1),
+                              frame.getLineSize(2), 0};
+
+        // Prepare dst data
+        uint8_t* dstData[4] = {nullptr};
+        int dstLineSize[4] = {0};
+        int numBytes = av_image_get_buffer_size(AV_PIX_FMT_RGB24, frame.getWidth(),
+                                                frame.getHeight(), 1);
+        if (numBytes < 0)
+        {
+            throw std::runtime_error("Could not get buffer size for RGB24");
+        }
+
+        if (!buffer)
+        {
+            throw std::invalid_argument("Destination buffer is null");
+        }
+
+        int ret = av_image_fill_arrays(
+            dstData, dstLineSize, static_cast<uint8_t*>(buffer), AV_PIX_FMT_RGB24,
+            frame.getWidth(), frame.getHeight(), 1 /* alignment */);
+        if (ret < 0)
+        {
+            char errBuf[256];
+            av_strerror(ret, errBuf, sizeof(errBuf));
+            throw std::runtime_error(std::string("av_image_fill_arrays failed: ") +
+                                     errBuf);
+        }
+
+        int result = sws_scale(swsContext, srcData, srcLineSize, 0, frame.getHeight(),
+                               dstData, dstLineSize);
+        if (result <= 0)
+        {
+            throw std::runtime_error("sws_scale failed for YUV422P->RGB24");
+        }
+    }
+
+  private:
+    struct SwsContext* swsContext;
+};
+
+} // namespace cpu
+} // namespace conversion
+} // namespace celux

--- a/include/CeLux/conversion/cpu/YUV444P10ToRGB48.hpp
+++ b/include/CeLux/conversion/cpu/YUV444P10ToRGB48.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+#include "CPUConverter.hpp"
+
+namespace celux
+{
+namespace conversion
+{
+namespace cpu
+{
+
+/**
+ * @brief Converter for 10-bit YUV444P10LE to 48-bit RGB (RGB48LE) on CPU.
+ */
+class YUV444P10ToRGB48 : public ConverterBase
+{
+  public:
+    YUV444P10ToRGB48() : ConverterBase(), swsContext(nullptr)
+    {
+    }
+    ~YUV444P10ToRGB48()
+    {
+        if (swsContext)
+        {
+            sws_freeContext(swsContext);
+            swsContext = nullptr;
+        }
+    }
+
+    void convert(celux::Frame& frame, void* buffer) override
+    {
+        if (frame.getPixelFormat() != AV_PIX_FMT_YUV444P10LE)
+        {
+            throw std::invalid_argument(
+                "Unsupported pixel format for YUV444P10ToRGB48 converter");
+        }
+
+        if (!swsContext)
+        {
+            swsContext = sws_getContext(frame.getWidth(), frame.getHeight(),
+                                        AV_PIX_FMT_YUV444P10LE, // source
+                                        frame.getWidth(), frame.getHeight(),
+                                        AV_PIX_FMT_RGB48LE, // destination
+                                        SWS_BILINEAR, nullptr, nullptr, nullptr);
+
+            if (!swsContext)
+            {
+                throw std::runtime_error("Failed to initialize swsContext for "
+                                         "YUV444P10->RGB48 conversion");
+            }
+
+            int srcRange = 0;
+            int dstRange = 1;
+            const int* srcMatrix = sws_getCoefficients(SWS_CS_DEFAULT);
+            const int* dstMatrix = sws_getCoefficients(SWS_CS_DEFAULT);
+            sws_setColorspaceDetails(swsContext, srcMatrix, srcRange, dstMatrix,
+                                     dstRange, 0, 1 << 16, 1 << 16);
+        }
+
+        const uint8_t* srcData[4] = {frame.getData(0), frame.getData(1),
+                                     frame.getData(2), nullptr};
+        int srcLineSize[4] = {frame.getLineSize(0), frame.getLineSize(1),
+                              frame.getLineSize(2), 0};
+
+        uint8_t* dstData[4] = {nullptr};
+        int dstLineSize[4] = {0};
+
+        int numBytes = av_image_get_buffer_size(AV_PIX_FMT_RGB48LE, frame.getWidth(),
+                                                frame.getHeight(), 1);
+        if (numBytes < 0)
+        {
+            throw std::runtime_error("Could not get buffer size for RGB48LE");
+        }
+
+        if (!buffer)
+        {
+            throw std::invalid_argument("Destination buffer is null");
+        }
+
+        int ret = av_image_fill_arrays(
+            dstData, dstLineSize, static_cast<uint8_t*>(buffer), AV_PIX_FMT_RGB48LE,
+            frame.getWidth(), frame.getHeight(), 1 /* alignment */);
+        if (ret < 0)
+        {
+            char errBuf[256];
+            av_strerror(ret, errBuf, sizeof(errBuf));
+            throw std::runtime_error(std::string("av_image_fill_arrays failed: ") +
+                                     errBuf);
+        }
+
+        int result = sws_scale(swsContext, srcData, srcLineSize, 0, frame.getHeight(),
+                               dstData, dstLineSize);
+        if (result <= 0)
+        {
+            throw std::runtime_error("sws_scale failed for YUV444P10->RGB48");
+        }
+    }
+
+  private:
+    struct SwsContext* swsContext;
+};
+
+} // namespace cpu
+} // namespace conversion
+} // namespace celux

--- a/include/CeLux/conversion/cpu/YUV444P12ToRGB48.hpp
+++ b/include/CeLux/conversion/cpu/YUV444P12ToRGB48.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+#include "CPUConverter.hpp"
+
+namespace celux
+{
+namespace conversion
+{
+namespace cpu
+{
+
+/**
+ * @brief Converter for 12-bit YUV444P12LE to 48-bit RGB (RGB48LE) on CPU.
+ */
+class YUV444P12ToRGB48 : public ConverterBase
+{
+  public:
+    YUV444P12ToRGB48() : ConverterBase(), swsContext(nullptr)
+    {
+    }
+    ~YUV444P12ToRGB48()
+    {
+        if (swsContext)
+        {
+            sws_freeContext(swsContext);
+            swsContext = nullptr;
+        }
+    }
+
+    void convert(celux::Frame& frame, void* buffer) override
+    {
+        if (frame.getPixelFormat() != AV_PIX_FMT_YUV444P12LE)
+        {
+            throw std::invalid_argument(
+                "Unsupported pixel format for YUV444P12ToRGB48 converter");
+        }
+
+        if (!swsContext)
+        {
+            swsContext = sws_getContext(frame.getWidth(), frame.getHeight(),
+                                        AV_PIX_FMT_YUV444P12LE, // source
+                                        frame.getWidth(), frame.getHeight(),
+                                        AV_PIX_FMT_RGB48LE, // destination
+                                        SWS_BILINEAR, nullptr, nullptr, nullptr);
+
+            if (!swsContext)
+            {
+                throw std::runtime_error("Failed to initialize swsContext for "
+                                         "YUV444P12->RGB48 conversion");
+            }
+
+            int srcRange = 0;
+            int dstRange = 1;
+            const int* srcMatrix = sws_getCoefficients(SWS_CS_DEFAULT);
+            const int* dstMatrix = sws_getCoefficients(SWS_CS_DEFAULT);
+            sws_setColorspaceDetails(swsContext, srcMatrix, srcRange, dstMatrix,
+                                     dstRange, 0, 1 << 16, 1 << 16);
+        }
+
+        const uint8_t* srcData[4] = {frame.getData(0), frame.getData(1),
+                                     frame.getData(2), nullptr};
+        int srcLineSize[4] = {frame.getLineSize(0), frame.getLineSize(1),
+                              frame.getLineSize(2), 0};
+
+        uint8_t* dstData[4] = {nullptr};
+        int dstLineSize[4] = {0};
+
+        int numBytes = av_image_get_buffer_size(AV_PIX_FMT_RGB48LE, frame.getWidth(),
+                                                frame.getHeight(), 1);
+        if (numBytes < 0)
+        {
+            throw std::runtime_error("Could not get buffer size for RGB48LE");
+        }
+
+        if (!buffer)
+        {
+            throw std::invalid_argument("Destination buffer is null");
+        }
+
+        int ret = av_image_fill_arrays(
+            dstData, dstLineSize, static_cast<uint8_t*>(buffer), AV_PIX_FMT_RGB48LE,
+            frame.getWidth(), frame.getHeight(), 1 /* alignment */);
+        if (ret < 0)
+        {
+            char errBuf[256];
+            av_strerror(ret, errBuf, sizeof(errBuf));
+            throw std::runtime_error(std::string("av_image_fill_arrays failed: ") +
+                                     errBuf);
+        }
+
+        int result = sws_scale(swsContext, srcData, srcLineSize, 0, frame.getHeight(),
+                               dstData, dstLineSize);
+        if (result <= 0)
+        {
+            throw std::runtime_error("sws_scale failed for YUV444P12->RGB48");
+        }
+    }
+
+  private:
+    struct SwsContext* swsContext;
+};
+
+} // namespace cpu
+} // namespace conversion
+} // namespace celux

--- a/include/CeLux/conversion/cpu/YUV444P8ToRGB24.hpp
+++ b/include/CeLux/conversion/cpu/YUV444P8ToRGB24.hpp
@@ -1,0 +1,108 @@
+#pragma once
+
+#include "CPUConverter.hpp"
+
+namespace celux
+{
+namespace conversion
+{
+namespace cpu
+{
+
+/**
+ * @brief Converter for 8-bit YUV444P (YUV444P) to 24-bit RGB (RGB24) on CPU.
+ */
+class YUV444P8ToRGB24 : public ConverterBase
+{
+  public:
+    YUV444P8ToRGB24() : ConverterBase(), swsContext(nullptr)
+    {
+    }
+    ~YUV444P8ToRGB24()
+    {
+        if (swsContext)
+        {
+            sws_freeContext(swsContext);
+            swsContext = nullptr;
+        }
+    }
+
+    void convert(celux::Frame& frame, void* buffer) override
+    {
+        if (frame.getPixelFormat() != AV_PIX_FMT_YUV444P)
+        {
+            throw std::invalid_argument(
+                "Unsupported pixel format for YUV444P8ToRGB24 converter");
+        }
+
+        if (!swsContext)
+        {
+            swsContext = sws_getContext(frame.getWidth(), frame.getHeight(),
+                                        AV_PIX_FMT_YUV444P, // source
+                                        frame.getWidth(), frame.getHeight(),
+                                        AV_PIX_FMT_RGB24, // destination
+                                        SWS_BILINEAR, nullptr, nullptr, nullptr);
+
+            if (!swsContext)
+            {
+                throw std::runtime_error("Failed to initialize swsContext for "
+                                         "YUV444P->RGB24 conversion");
+            }
+
+            // Optionally set colorspace
+            int srcRange = 0;
+            int dstRange = 1;
+            const int* srcMatrix = sws_getCoefficients(SWS_CS_DEFAULT);
+            const int* dstMatrix = sws_getCoefficients(SWS_CS_DEFAULT);
+            sws_setColorspaceDetails(swsContext, srcMatrix, srcRange, dstMatrix,
+                                     dstRange, 0, 1 << 16, 1 << 16);
+        }
+
+        // Source data
+        const uint8_t* srcData[4] = {frame.getData(0), frame.getData(1),
+                                     frame.getData(2), nullptr};
+        int srcLineSize[4] = {frame.getLineSize(0), frame.getLineSize(1),
+                              frame.getLineSize(2), 0};
+
+        // Destination data
+        uint8_t* dstData[4] = {nullptr};
+        int dstLineSize[4] = {0};
+
+        int numBytes = av_image_get_buffer_size(AV_PIX_FMT_RGB24, frame.getWidth(),
+                                                frame.getHeight(), 1);
+        if (numBytes < 0)
+        {
+            throw std::runtime_error("Could not get buffer size for RGB24");
+        }
+
+        if (!buffer)
+        {
+            throw std::invalid_argument("Destination buffer is null");
+        }
+
+        int ret = av_image_fill_arrays(
+            dstData, dstLineSize, static_cast<uint8_t*>(buffer), AV_PIX_FMT_RGB24,
+            frame.getWidth(), frame.getHeight(), 1 /* alignment */);
+        if (ret < 0)
+        {
+            char errBuf[256];
+            av_strerror(ret, errBuf, sizeof(errBuf));
+            throw std::runtime_error(std::string("av_image_fill_arrays failed: ") +
+                                     errBuf);
+        }
+
+        int result = sws_scale(swsContext, srcData, srcLineSize, 0, frame.getHeight(),
+                               dstData, dstLineSize);
+        if (result <= 0)
+        {
+            throw std::runtime_error("sws_scale failed for YUV444P->RGB24");
+        }
+    }
+
+  private:
+    struct SwsContext* swsContext;
+};
+
+} // namespace cpu
+} // namespace conversion
+} // namespace celux

--- a/src/CeLux/backends/Decoder.cpp
+++ b/src/CeLux/backends/Decoder.cpp
@@ -446,6 +446,21 @@ bool Decoder::decodeNextFrame(void* buffer, double* frame_timestamp)
     }
 }
 
+bool Decoder::seekFrame(int frameIndex)
+{
+    CELUX_TRACE("Seeking to frame index: {}", frameIndex);
+
+    if (frameIndex < 0 || frameIndex > properties.totalFrames)
+    {
+        CELUX_WARN("Frame index out of bounds: {}", frameIndex);
+        return false;
+    }
+
+    double timestamp = static_cast<double>(frameIndex) / properties.fps;
+    return seek(timestamp); // Call existing timestamp-based seek method
+}
+
+
 bool Decoder::seek(double timestamp)
 {
     CELUX_TRACE("Seeking to timestamp: {}", timestamp);

--- a/src/CeLux/python/Bindings.cpp
+++ b/src/CeLux/python/Bindings.cpp
@@ -22,7 +22,7 @@ PYBIND11_MODULE(celux, m)
              py::arg("filters") = std::vector<std::shared_ptr<FilterBase>>(),
              py::arg("tensor_shape") = "HWC")
         .def("read_frame", &VideoReader::readFrame)
-        .def("seek", &VideoReader::seek)
+        .def_property_readonly("properties", &VideoReader::getProperties)
         .def("supported_codecs", &VideoReader::supportedCodecs)
         .def("get_properties", &VideoReader::getProperties)
         .def("__getitem__", &VideoReader::operator[])

--- a/src/CeLux/python/VideoReader.cpp
+++ b/src/CeLux/python/VideoReader.cpp
@@ -540,6 +540,10 @@ torch::ScalarType VideoReader::findTypeFromBitDepth()
         CELUX_DEBUG("Setting tensor data type to torch::kUInt16");
         torchDataType = torch::kUInt16;
         break;
+    case 12:
+        CELUX_DEBUG("Setting tensor data type to torch::kUInt16");
+		torchDataType = torch::kUInt16;
+		break;
     case 16:
         CELUX_DEBUG("Setting tensor data type to torch::kUInt16");
         torchDataType = torch::kUInt16;

--- a/tests/usage/example1.py
+++ b/tests/usage/example1.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import time
+import logging
+
+# Append the parent directory to system path to allow package import
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+# Configure logging for clean output
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+import celux
+
+def test_video(input_video):
+    """
+    Test the VideoReader class with a sample video.
+    
+    Args:
+        input_video (str): Path to the input video file.
+    """
+    if not os.path.exists(input_video):
+        logging.error(f"❌ Missing test video: {input_video}")
+        return
+
+    try:
+        logging.info(f"🔍 Loading video: {input_video}")
+
+        # Initialize the video reader
+        reader = celux.VideoReader(input_video)
+
+        # Decode the first frame
+        first_frame = next(iter(reader))
+        if first_frame is None:
+            logging.error("❌ Failed to decode first frame")
+            return
+        
+        logging.info("✅ Video loaded successfully.")
+
+        # Benchmark frame decoding speed
+        num_frames = 100  # Adjust this for more accuracy
+        start_time = time.time()
+        
+        for _ in range(num_frames):
+            _ = next(iter(reader), None)
+        
+        elapsed_time = time.time() - start_time
+        fps = num_frames / elapsed_time if elapsed_time > 0 else 0
+
+        logging.info(f"⚡ Benchmark: {fps:.2f} FPS for {num_frames} frames.")
+
+    except Exception as e:
+        logging.error(f"❌ Error during processing: {e}")
+
+if __name__ == "__main__":
+    # Allow passing a video file as an argument or use a default test video
+    default_video = os.path.join(os.path.dirname(__file__), "..", "data", "default", "BigBuckBunny.mp4")
+    input_video = sys.argv[1] if len(sys.argv) > 1 else default_video
+
+    test_video(input_video)


### PR DESCRIPTION
### Version 0.5.7 (2025-1-23)

- **New color format support** Added CPU-based conversions for:
  - 12-bit YUV (420, 422, and 444)
  - 10-bit YUV444
  - ProRes 4444 with alpha (10-bit or 12-bit)
  - Anything NOT 8-bit uses `uint-16` tensors.

- **Notes on rawvideo** Raw `.yuv` files still require specifying resolution and pixel format manually. (`-f rawvideo -pix_fmt yuv420p -s 1920x1080 …`)
  - **IN PROGRESS****

- **Other improvements**
  - Minor cleanups in converter classes.
  - Updated tests to cover the newly supported pixel formats.