### PR TITLE
### **Version 0.5.8 (2025-1-24)**

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 The name **CeLux** is derived from the Latin words `celer` (speed) and `lux` (light), reflecting its commitment to speed and efficiency.
 
-# [Check out the latest changes](docs/CHANGELOG.md#version-057)
+# [Check out the latest changes](docs/CHANGELOG.md#version-058)
 
 ## 📚 Documentation
 

--- a/build.py
+++ b/build.py
@@ -3,7 +3,7 @@ import subprocess
 import shutil
 
 # Hardcoded version for both CPU and CUDA builds
-VERSION = "0.5.7"
+VERSION = "0.5.8"
 
 def build_package(is_cuda=False):
     """
@@ -64,7 +64,7 @@ def main():
     build_package(is_cuda=False)
 
     # Build the CUDA version
-    build_package(is_cuda=True)
+   # build_package(is_cuda=True)
 
 if __name__ == "__main__":
     main()

--- a/celux/celux.pyi
+++ b/celux/celux.pyi
@@ -34,9 +34,88 @@ class VideoReader:
             input_path (str): Path to the video file.
             num_threads (int, optional): Number of threads for decoding. Defaults to half of CPU cores.
             filters (Optional[List[FilterBase]]): List of filters to apply to the video.
-                - Example: filters = [("scale", "1280:720"), ("hue", "0.5")]
             tensor_shape (str, optional): Shape format of the output tensor. Defaults to "HWC".
         """
+        ...
+
+    @property
+    def width(self) -> int:
+        """Get the video width."""
+        ...
+
+    @property
+    def height(self) -> int:
+        """Get the video height."""
+        ...
+
+    @property
+    def fps(self) -> float:
+        """Get the frames per second of the video."""
+        ...
+
+    @property
+    def min_fps(self) -> float:
+        """Get the minimum frames per second of the video."""
+        ...
+
+    @property
+    def max_fps(self) -> float:
+        """Get the maximum frames per second of the video."""
+        ...
+
+    @property
+    def duration(self) -> float:
+        """Get the duration of the video in seconds."""
+        ...
+
+    @property
+    def total_frames(self) -> int:
+        """Get the total number of frames in the video."""
+        ...
+
+    @property
+    def pixel_format(self) -> str:
+        """Get the pixel format of the video."""
+        ...
+
+    @property
+    def has_audio(self) -> bool:
+        """Check if the video contains audio."""
+        ...
+
+    @property
+    def audio_bitrate(self) -> Optional[int]:
+        """Get the audio bitrate if available."""
+        ...
+
+    @property
+    def audio_channels(self) -> Optional[int]:
+        """Get the number of audio channels if available."""
+        ...
+
+    @property
+    def audio_sample_rate(self) -> Optional[int]:
+        """Get the audio sample rate if available."""
+        ...
+
+    @property
+    def audio_codec(self) -> Optional[str]:
+        """Get the audio codec name if available."""
+        ...
+
+    @property
+    def bit_depth(self) -> int:
+        """Get the bit depth of the video."""
+        ...
+
+    @property
+    def aspect_ratio(self) -> str:
+        """Get the aspect ratio of the video."""
+        ...
+
+    @property
+    def codec(self) -> str:
+        """Get the video codec name."""
         ...
 
     def __call__(self, frame_range: Union[Tuple[int, int], Tuple[float, float],
@@ -44,28 +123,12 @@ class VideoReader:
         """
         Set the frame range for the video reader.
 
-        This method allows setting a **range** using **frame indices (int)** or **timestamps (float)**.
-
-        **Example:**
-        ```python
-        with VideoReader('input.mp4')([10, 20]) as reader:  # Using frames
-            for frame in reader:
-                process_frame(frame)
-
-        with VideoReader('input.mp4')([1.5, 2.5]) as reader:  # Using timestamps
-            for frame in reader:
-                process_frame(frame)
-        ```
-
         Args:
             frame_range (Union[Tuple[int, int], Tuple[float, float], List[int], List[float]]):
                 A tuple or list containing the start and end frame indices or timestamps.
-
+        
         Returns:
             VideoReader: The video reader object itself.
-
-        Raises:
-            ValueError: If `frame_range` is not a tuple or list of two **ints or two floats**.
         """
         ...
 
@@ -94,18 +157,9 @@ class VideoReader:
         """
         Set the playback range using either **frame numbers (int)** or **timestamps (float)**.
 
-        **Example:**
-        ```python
-        reader.set_range(10, 50)      # Frame-based range
-        reader.set_range(1.5, 2.5)    # Time-based range
-        ```
-
         Args:
             start (Union[int, float]): Starting frame number or timestamp.
             end (Union[int, float]): Ending frame number or timestamp.
-
-        Raises:
-            ValueError: If `start` and `end` are not both **ints** or both **floats**.
         """
         ...
 
@@ -115,31 +169,6 @@ class VideoReader:
 
         Returns:
             List[str]: List of supported codec names.
-        """
-        ...
-
-    def get_properties(self) -> dict:
-        """
-        Retrieve video properties.
-
-        Returns:
-            dict: A dictionary containing the following properties:
-                - width (int): Video width.
-                - height (int): Video height.
-                - fps (float): Frames per second.
-                - min_fps (float): Minimum frames per second.
-                - max_fps (float): Maximum frames per second.
-                - duration (float): Video duration in seconds.
-                - total_frames (int): Total number of frames.
-                - pixel_format (str): Video pixel format.
-                - has_audio (bool): Whether the video contains audio.
-                - audio_bitrate (Optional[int]): Audio bitrate (if applicable).
-                - audio_channels (Optional[int]): Number of audio channels.
-                - audio_sample_rate (Optional[int]): Audio sample rate.
-                - audio_codec (Optional[str]): Audio codec name.
-                - bit_depth (int): Bit depth of the video.
-                - aspect_ratio (str): Video aspect ratio.
-                - codec (str): Video codec name.
         """
         ...
 
@@ -167,9 +196,6 @@ class VideoReader:
 
         Returns:
             torch.Tensor: The next frame as a PyTorch tensor.
-
-        Raises:
-            StopIteration: Raised when no more frames are available.
         """
         ...
 
@@ -186,11 +212,6 @@ class VideoReader:
         """
         Exit the context manager.
 
-        Args:
-            exc_type (Optional[type]): The exception type, if any.
-            exc_value (Optional[BaseException]): The exception value, if any.
-            traceback (Optional[Any]): The traceback object, if any.
-
         Returns:
             bool: False to propagate exceptions, True to suppress them.
         """
@@ -202,18 +223,17 @@ class VideoReader:
         """
         ...
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: Union[int, float]) -> torch.Tensor:
         """
-        Retrieve a specific property of the video.
+        Retrieve a frame at a specific timestamp or frame index.
 
         Args:
-            key (str): Property name.
+            key (Union[int, float]): Frame index (int) or timestamp (float).
 
         Returns:
-            Any: The value of the requested property.
+            torch.Tensor: The retrieved frame.
         """
         ...
-
 # This file is autogenerated. Do not modify manually.
 from typing import List, Optional, Any, Tuple
 from enum import Enum

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,30 @@
 ## 📈 Changelog
 
+### **Version 0.5.8 (2025-1-24)**  
+
+#### **Improved Property Access for VideoReader**  
+- Added direct property access for video metadata.  
+- Users can now retrieve video properties directly instead of accessing `properties["key"]`.  
+- Example:  
+  ```python
+  reader = VideoReader("test.mp4")
+  print(reader.width)  # Instead of video.properties["width"]
+  print(reader.fps)  # Instead of video.properties["fps"]
+  ```
+
+- **Available properties:**  
+  `width, height, fps, min_fps, max_fps, duration, total_frames, pixel_format, has_audio, audio_bitrate, audio_channels, audio_sample_rate, audio_codec, bit_depth, aspect_ratio, codec`
+
+#### **`__getitem__` Seeking Behavior Update**  
+- `__getitem__` now only accepts **seconds (float)** for seeking.  
+- Frame-based seeking (int) is currently **not supported** via `__getitem__`.  
+- Example usage:  
+  ```python
+  reader = VideoReader("test.mp4")
+  frame = reader[2.5]  # Seeks to 2.5 seconds into the video
+  ```
+
+
 ### Version 0.5.7 (2025-1-23)
 
 - **New color format support**  

--- a/include/CeLux/Factory.hpp
+++ b/include/CeLux/Factory.hpp
@@ -251,7 +251,6 @@ class Factory
             return 12;
 
         // ProRes4444 often decodes to YUVA444P10 or YUVA444P16.
-        // If you know specifically it's 10-bit:
         case AV_PIX_FMT_YUVA444P10LE:
             return 10;
         // Or if you also want to handle 12-bit alpha:

--- a/include/CeLux/backends/Decoder.hpp
+++ b/include/CeLux/backends/Decoder.hpp
@@ -29,8 +29,6 @@ class Decoder
         std::string audioCodec;
         double min_fps;
         double max_fps;
-        bool isRawVideo; // ✅ New: Identifies raw video formats
-        bool needsRemux; // ✅ New: Flag if remuxing is needed
     };
 
     Decoder() = default;
@@ -71,10 +69,6 @@ class Decoder
 
     bool initFilterGraph();
     void set_sw_pix_fmt(AVCodecContextPtr& codecCtx, int bitDepth);
-
-    // ✅ New Methods for Handling Raw Video & Remuxing
-    bool isRawFormat(const std::string& filePath);
-    std::string remuxToSupportedFormat(const std::string& inputPath);
 
     AVFilterGraphPtr filter_graph_;
     AVFilterContext* buffersrc_ctx_;

--- a/include/CeLux/python/VideoReader.hpp
+++ b/include/CeLux/python/VideoReader.hpp
@@ -34,8 +34,7 @@ class VideoReader
      * @param key The property key to access.
      * @return py::object The value associated with the key.
      */
-    py::object operator[](const std::string& key) const;
-
+    py::object operator[](py::object key);
     /**
      * @brief Read a frame from the video.
      *

--- a/src/CeLux/python/Bindings.cpp
+++ b/src/CeLux/python/Bindings.cpp
@@ -23,6 +23,54 @@ PYBIND11_MODULE(celux, m)
              py::arg("tensor_shape") = "HWC")
         .def("read_frame", &VideoReader::readFrame)
         .def_property_readonly("properties", &VideoReader::getProperties)
+        .def_property_readonly("properties",
+                               &VideoReader::getProperties) // Keep full dict access
+        .def_property_readonly("width", [](const VideoReader& self)
+                               { return self.getProperties()["width"].cast<int>(); })
+        .def_property_readonly("height", [](const VideoReader& self)
+                               { return self.getProperties()["height"].cast<int>(); })
+        .def_property_readonly("fps", [](const VideoReader& self)
+                               { return self.getProperties()["fps"].cast<double>(); })
+        .def_property_readonly(
+            "min_fps", [](const VideoReader& self)
+            { return self.getProperties()["min_fps"].cast<double>(); })
+        .def_property_readonly(
+            "max_fps", [](const VideoReader& self)
+            { return self.getProperties()["max_fps"].cast<double>(); })
+        .def_property_readonly(
+            "duration", [](const VideoReader& self)
+            { return self.getProperties()["duration"].cast<double>(); })
+        .def_property_readonly(
+            "total_frames", [](const VideoReader& self)
+            { return self.getProperties()["total_frames"].cast<int>(); })
+        .def_property_readonly(
+            "pixel_format", [](const VideoReader& self)
+            { return self.getProperties()["pixel_format"].cast<std::string>(); })
+        .def_property_readonly(
+            "has_audio", [](const VideoReader& self)
+            { return self.getProperties()["has_audio"].cast<bool>(); })
+        .def_property_readonly(
+            "audio_bitrate", [](const VideoReader& self)
+            { return self.getProperties()["audio_bitrate"].cast<int>(); })
+        .def_property_readonly(
+            "audio_channels", [](const VideoReader& self)
+            { return self.getProperties()["audio_channels"].cast<int>(); })
+        .def_property_readonly(
+            "audio_sample_rate", [](const VideoReader& self)
+            { return self.getProperties()["audio_sample_rate"].cast<int>(); })
+        .def_property_readonly(
+            "audio_codec", [](const VideoReader& self)
+            { return self.getProperties()["audio_codec"].cast<std::string>(); })
+        .def_property_readonly("bit_depth",
+                               [](const VideoReader& self) {
+                                   return self.getProperties()["bit_depth"].cast<int>();
+                               })
+        .def_property_readonly(
+            "aspect_ratio", [](const VideoReader& self)
+            { return self.getProperties()["aspect_ratio"].cast<double>(); })
+        .def_property_readonly(
+            "codec", [](const VideoReader& self)
+            { return self.getProperties()["codec"].cast<std::string>(); })
         .def("supported_codecs", &VideoReader::supportedCodecs)
         .def("get_properties", &VideoReader::getProperties)
         .def("__getitem__", &VideoReader::operator[])

--- a/tests/benchmarks/testspeed.py
+++ b/tests/benchmarks/testspeed.py
@@ -1,0 +1,45 @@
+import time
+import cv2
+import av
+import torch
+import sys
+import os
+# Adjust the path to include CeLux
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+from celux import VideoReader
+
+VIDEO_PATH = r"C:\Users\tjerf\Downloads\TAS_fpqg.mp4"
+
+def benchmark_opencv():
+    cap = cv2.VideoCapture(VIDEO_PATH)
+    start = time.time()
+    frame_count = 0
+    while cap.isOpened():
+        ret, _ = cap.read()
+        if not ret:
+            break
+        frame_count += 1
+    cap.release()
+    return frame_count / (time.time() - start)
+
+def benchmark_pyav():
+    container = av.open(VIDEO_PATH)
+    stream = container.streams.video[0]
+    start = time.time()
+    frame_count = 0
+    for frame in container.decode(stream):
+        frame_count += 1
+    return frame_count / (time.time() - start)
+
+def benchmark_celux():
+    reader = VideoReader(VIDEO_PATH)
+    start = time.time()
+    frame_count = 0
+    for _ in reader:
+        frame_count += 1
+    return frame_count / (time.time() - start)
+
+if __name__ == "__main__":
+    print(f"OpenCV FPS: {benchmark_opencv():.2f}")
+    print(f"PyAV FPS: {benchmark_pyav():.2f}")
+    print(f"CeLux FPS: {benchmark_celux():.2f}")

--- a/tests/test_color_fmts.py
+++ b/tests/test_color_fmts.py
@@ -50,7 +50,7 @@ def test_video_format_loading(video_file):
         reader = celux.VideoReader(video_path)
         logging.info(f"🔍 Loading video: {video_file}")
         # pixel_format is a property of the VideoReader class
-        logging.info(f"    - Pixel Format: {reader['pixel_format']}")
+        logging.info(f"    - Pixel Format: {reader.pixel_format}")
 
         first_frame = next(iter(reader))
         assert first_frame is not None, "❌ Failed to decode first frame"

--- a/tests/test_frame_range.py
+++ b/tests/test_frame_range.py
@@ -107,9 +107,9 @@ def extract_clip_celux_frames(video_path, start_frame, end_frame, output_video):
     # because we're passing integers. It decodes that exact slice.
     reader([start_frame, end_frame])
 
-    fps    = int(reader["fps"])
-    width  = reader["width"]
-    height = reader["height"]
+    fps    = reader.fps
+    width  = reader.width
+    height = reader.height
 
     fourcc = cv2.VideoWriter_fourcc(*"mp4v")
     out    = cv2.VideoWriter(output_video, fourcc, fps, (width, height))

--- a/tests/test_time_range.py
+++ b/tests/test_time_range.py
@@ -12,7 +12,8 @@ import matplotlib.pyplot as plt
 # Adjust if needed to locate your Celux package
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from celux import VideoReader
-
+import celux
+celux.set_log_level(celux.LogLevel.off)  # trace, debug, info, error, warn, critical, off
 # ----------------------------------------------------------------------------
 # Configuration
 # ----------------------------------------------------------------------------
@@ -100,9 +101,9 @@ def extract_clip_celux_times(video_path, start_time, end_time, output_video):
     # That means decode from start_time s up to end_time s
     reader([start_time, end_time])
 
-    fps    = int(reader["fps"])
-    width  = reader["width"]
-    height = reader["height"]
+    fps    = reader.fps
+    width  = reader.width
+    height = reader.height
 
     fourcc = cv2.VideoWriter_fourcc(*"mp4v")
     out    = cv2.VideoWriter(output_video, fourcc, fps, (width, height))

--- a/tests/usage/example1.py
+++ b/tests/usage/example1.py
@@ -27,7 +27,8 @@ def test_video(input_video):
 
         # Initialize the video reader
         reader = celux.VideoReader(input_video)
-
+        print(reader.pixel_format)
+        print(reader.properties)
         # Decode the first frame
         first_frame = next(iter(reader))
         if first_frame is None:

--- a/tests/usage/seek.py
+++ b/tests/usage/seek.py
@@ -1,0 +1,139 @@
+import os
+import sys
+import time
+import logging
+import cv2
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Append the parent directory to system path to allow package import
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+# Configure logging for clean output
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+import celux
+
+def get_opencv_frame(video_path, seek_value, seek_by="time"):
+    """
+    Extract a frame using OpenCV, either by time (seconds) or frame index.
+
+    Args:
+        video_path (str): Path to the video file.
+        seek_value (float or int): Timestamp (seconds) or frame index.
+        seek_by (str): "time" for timestamp, "frame" for frame index.
+
+    Returns:
+        frame (np.array): Extracted frame.
+    """
+    cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        logging.error("❌ OpenCV failed to open video.")
+        return None
+
+    fps = cap.get(cv2.CAP_PROP_FPS)
+
+    if seek_by == "time":
+        frame_number = int(seek_value * fps)  # Convert time to frame number
+    else:
+        frame_number = seek_value
+
+    cap.set(cv2.CAP_PROP_POS_FRAMES, frame_number)
+    
+    ret, frame = cap.read()
+    cap.release()
+    
+    if not ret:
+        logging.error(f"❌ OpenCV failed to seek to {seek_value} ({seek_by}).")
+        return None
+
+    return frame
+
+
+
+
+def get_celux_frame(video_path, seek_value):
+    """
+    Extract a frame using CeLux by timestamp or frame index.
+
+    Args:
+        video_path (str): Path to the video file.
+        seek_value (float or int): Timestamp (seconds) or frame index.
+
+    Returns:
+        frame (torch.Tensor): Extracted frame.
+    """
+    reader = celux.VideoReader(video_path)
+    
+    try:
+        frame = reader[seek_value]  # CeLux supports both float (time) & int (frame index)
+        return frame.numpy()  # Convert to NumPy for visualization
+    except Exception as e:
+        logging.error(f"❌ CeLux failed to seek to {seek_value}: {e}")
+        return None
+
+
+def compare_seeking(video_path, seek_values, seek_by="time"):
+    """
+    Compare frame extraction speed and accuracy between CeLux and OpenCV.
+
+    Args:
+        video_path (str): Path to the video file.
+        seek_values (list): List of timestamps (float) or frame indexes (int).
+        seek_by (str): "time" or "frame".
+    """
+    logging.info(f"🔍 Comparing CeLux vs OpenCV ({seek_by})...")
+
+    for seek_value in seek_values:
+        logging.info(f"⏩ Seeking to {seek_value} ({seek_by})...")
+
+        # Benchmark OpenCV
+        start_time = time.time()
+        frame_opencv = get_opencv_frame(video_path, seek_value, seek_by)  # Pass correct seek mode
+        time_opencv = time.time() - start_time
+
+        # Benchmark CeLux
+        start_time = time.time()
+        frame_celux = get_celux_frame(video_path, seek_value)
+        time_celux = time.time() - start_time
+
+        if frame_opencv is None or frame_celux is None:
+            logging.warning(f"⚠️ Skipping {seek_value} ({seek_by}) due to missing frame.")
+            continue
+
+        # Resize both frames to 256x256 for easier side-by-side comparison
+        frame_opencv_resized = cv2.resize(frame_opencv, (256, 256))
+        frame_celux_resized = cv2.resize(frame_celux, (256, 256))
+
+        # Display results
+        fig, axes = plt.subplots(1, 2, figsize=(8, 4))
+        axes[0].imshow(cv2.cvtColor(frame_opencv_resized, cv2.COLOR_BGR2RGB))
+        axes[0].set_title(f"OpenCV ({time_opencv:.3f}s)")
+
+        axes[1].imshow(frame_celux_resized)
+        axes[1].set_title(f"CeLux ({time_celux:.3f}s)")
+
+        for ax in axes:
+            ax.axis("off")
+
+        plt.suptitle(f"Comparison at {seek_value} ({seek_by})")
+        plt.show()
+
+        logging.info(f"✅ Comparison at {seek_value}: OpenCV {time_opencv:.3f}s | CeLux {time_celux:.3f}s")
+
+
+if __name__ == "__main__":
+    # Default test video
+    default_video = os.path.join(os.path.dirname(__file__), "..", "data", "default", "BigBuckBunny.mp4")
+    input_video = sys.argv[1] if len(sys.argv) > 1 else default_video
+
+    if not os.path.exists(input_video):
+        logging.error(f"❌ Missing test video: {input_video}")
+        sys.exit(1)
+
+    # Test seeking
+    seek_times = [1.0, 2.5, 5.0, 10.0, 60.0]  # Seconds
+    seek_frames = [10, 50, 100, 200]  # Frame numbers
+
+    compare_seeking(input_video, seek_times, "time")
+    compare_seeking(input_video, seek_frames, "frame")


### PR DESCRIPTION
### **Version 0.5.8 (2025-1-24)**

#### **Improved Property Access for VideoReader**
- Added direct property access for video metadata.
- Users can now retrieve video properties directly instead of accessing `properties["key"]`.
- Example: ```python reader = VideoReader("test.mp4") print(reader.width)  # Instead of video.properties["width"] print(reader.fps)  # Instead of video.properties["fps"] ```

- **Available properties:** `width, height, fps, min_fps, max_fps, duration, total_frames, pixel_format, has_audio, audio_bitrate, audio_channels, audio_sample_rate, audio_codec, bit_depth, aspect_ratio, codec`

#### **`__getitem__` Seeking Behavior Update**
- `__getitem__` now only accepts **seconds (float)** for seeking.
- Frame-based seeking (int) is currently **not supported** via `__getitem__`.
- Example usage: ```python reader = VideoReader("test.mp4") frame = reader[2.5]  # Seeks to 2.5 seconds into the video ```