### PR TITLE
feat(encode): async fan-out pipeline + passthrough trims/transcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Async fan-out encode pipeline.** RGB→YUV swscale (single-threaded, the bulk
+  of CPU encode cost) is now fanned out across a pool of convert workers; a
+  single submit thread pulls frames in sequence order via a seq-keyed reorder
+  map and calls `avcodec_send_frame` (x264 is one stateful context, so submit
+  must stay sequential). GPU/NVENC jobs skip the convert pool and convert on the
+  submit thread (zero-copy). Bounded in-flight backpressure + recycled
+  staging/YUV pools; teardown drains and joins all workers, re-raising the first
+  worker error at `close()`.
+- **`add_passthrough(allow_transcode=...)`.** Streams the output container
+  cannot stream-copy (e.g. AAC into WebM, SubRip into MP4) are re-encoded to the
+  container default instead of being silently dropped.
+- **Encode pipeline test suite** (`tests/test_async_encode_pipeline.py`):
+  frame-count + order integrity, PSNR floor, input-shape rejection, mid-stream
+  error teardown, and an nvdec→nvenc smoke test (CPU + CUDA; CUDA variants skip
+  without hardware). Manual scripts `test_passthrough.py` / `test_transcode.py`
+  cover the trim + transcode-fallback paths.
+
+### Fixed
+
+- **Encoder: out-of-bounds read on an undersized `encode_frame` tensor.**
+  `encode_frame` copied exactly `width*height*3` bytes from the tensor without
+  checking its size, so a smaller tensor read past the end of its storage. The
+  element count is now validated up front (while the GIL is held) and a
+  mismatch raises `ValueError` instead of reading out of bounds.
+
+### Removed
+
+- **Temporary `[encstat]` convert/encode timing instrumentation** (and its
+  per-frame atomics) used to profile the fan-out split; no longer needed.
+
 ## [0.11.1] - 2026-05-26
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,7 +221,7 @@ set(NELUX_FFMPEG_INCS "${NELUX_FFMPEG_DIR}/include")
 
 # Find import libraries
 set(_ffmpeg_lib_dir "${NELUX_FFMPEG_DIR}/lib")
-set(_ffmpeg_components avcodec avformat avutil avfilter swscale avdevice)
+set(_ffmpeg_components avcodec avformat avutil avfilter swscale swresample avdevice)
 
 if(WIN32)
   set(NELUX_FFMPEG_LIBS)
@@ -480,6 +480,7 @@ if(NELUX_BUILD_PYTHON)
       "/DELAYLOAD:avformat-62.dll"
       "/DELAYLOAD:avutil-60.dll"
       "/DELAYLOAD:swscale-9.dll"
+      "/DELAYLOAD:swresample-6.dll"
       "/DELAYLOAD:avfilter-11.dll"
       "/DELAYLOAD:avdevice-62.dll"
     )
@@ -600,6 +601,7 @@ if(WIN32 AND NELUX_BUILD_PYTHON)
       "${NELUX_FFMPEG_DIR}/bin/avformat-*.dll"
       "${NELUX_FFMPEG_DIR}/bin/avutil-*.dll"
       "${NELUX_FFMPEG_DIR}/bin/swscale-*.dll"
+      "${NELUX_FFMPEG_DIR}/bin/swresample-*.dll"
       "${NELUX_FFMPEG_DIR}/bin/avfilter-*.dll"
       "${NELUX_FFMPEG_DIR}/bin/avdevice-*.dll"
     )

--- a/include/Nelux/backends/Encoder.hpp
+++ b/include/Nelux/backends/Encoder.hpp
@@ -9,6 +9,11 @@
 #include <map>
 #include <string>
 
+// Forward declarations for audio-transcode types (full defs pulled into the
+// .cpp from libswresample/swresample.h and libavutil/audio_fifo.h).
+struct SwrContext;
+struct AVAudioFifo;
+
 namespace nelux
 {
 
@@ -76,6 +81,23 @@ class Encoder
     void writePacket();
     void close();
 
+    // Copy (remux) audio and/or subtitle streams from `source` into the output
+    // container, equivalent to ffmpeg `-c:a copy -c:s copy`. Must be called
+    // before the first encodeFrame (i.e. before the container header is
+    // written). `startSec`/`endSec` packet-gate the streams: only source
+    // packets with pts in [startSec, endSec) are written, rebased so startSec
+    // maps to output t=0 (aligned with video frame 0). endSec < 0 = no limit.
+    //
+    // When a source stream's codec cannot be stream-copied into the output
+    // container (e.g. AC3 into webm, subrip into mp4) and `allowTranscode` is
+    // true, the stream is decoded and re-encoded to the container's default
+    // codec instead of being skipped (audio -> e.g. aac/opus; text subtitles ->
+    // e.g. mov_text/webvtt). Bitmap subtitles and undecodable streams are still
+    // skipped with a warning.
+    void addInputStreams(const std::string& source, bool wantAudio,
+                         bool wantSubtitles, double startSec, double endSec,
+                         bool allowTranscode);
+
     // Check if hardware encoding is active
     bool isHardwareEncoder() const { return hwDeviceCtx != nullptr; }
 
@@ -98,6 +120,37 @@ class Encoder
     std::string
     inferContainerFormat(const std::string& filename) const;
 
+    // --- Audio/subtitle passthrough (copy or transcode) ----------------------
+    void ensureHeaderWritten();          // writes container header once, lazily
+    void pumpPassthrough(double uptoSec);// drain source pkts up to a video time
+    double packetTimeSec(const AVPacket* p) const;
+
+    // How one copied/transcoded source stream is handled.
+    enum class PassMode { Copy, TranscodeAudio, TranscodeSubtitle };
+
+    struct PassStream
+    {
+        int srcIndex = -1;
+        AVStream* outStream = nullptr;
+        PassMode mode = PassMode::Copy;
+
+        // Transcode-only (null/zero for Copy):
+        AVCodecContextPtr dec;       // source decoder
+        AVCodecContextPtr enc;       // output encoder
+        SwrContext* swr = nullptr;   // audio resampler (dec fmt -> enc fmt)
+        AVAudioFifo* fifo = nullptr; // buffers resampled samples to frame_size
+        int64_t nextPts = 0;         // audio: running output sample counter
+    };
+
+    bool setupCopyStream(AVStream* in);          // create copy output stream
+    bool setupAudioTranscode(AVStream* in);      // decode+resample+encode setup
+    bool setupSubtitleTranscode(AVStream* in);   // text-subtitle transcode setup
+    void writeCopyPacket(PassStream& ps, AVPacket* p);     // rebase ts + write
+    void transcodeAudioPacket(PassStream& ps, AVPacket* p);// p==null => flush
+    void encodeAudioFromFifo(PassStream& ps, bool flush);  // fifo -> enc -> mux
+    void transcodeSubtitlePacket(PassStream& ps, AVPacket* p);
+    void flushTranscoders();                     // drain all transcode streams
+
     EncodingProperties properties;
     std::string filename;
     AVFormatContextPtr formatCtx;
@@ -109,6 +162,20 @@ class Encoder
     // Hardware encoding context (NVENC)
     AVBufferRef* hwDeviceCtx = nullptr;   // CUDA device context
     AVBufferRef* hwFramesCtx = nullptr;   // Hardware frames context
+
+    // Audio/subtitle passthrough state. The container header is written lazily
+    // (ensureHeaderWritten) so addInputStreams can register copied streams
+    // after construction but before the first frame.
+    bool headerWritten = false;
+    AVFormatContextPtr inputFormatCtx;        // source demuxer (audio/sub copy)
+    std::map<int, PassStream> passMap;        // source stream idx -> handling
+    AVPacketPtr inPkt;                        // reusable read buffer for source
+    bool allowTranscode = false;             // re-encode streams that can't copy
+    double passStartSec = 0.0;                // trim start (seconds)
+    double passEndSec = -1.0;                 // trim end (<0 = no limit)
+    bool hasPassthrough = false;              // any stream copied/transcoded?
+    bool hasPending = false;                  // inPkt holds an un-written packet
+    bool passDone = false;                    // source exhausted / past endSec
 };
 
 } // namespace nelux

--- a/include/Nelux/python/VideoEncoder.hpp
+++ b/include/Nelux/python/VideoEncoder.hpp
@@ -3,10 +3,17 @@
 #define VIDEO_ENCODER_HPP
 
 #include "Encoder.hpp"
+#include <condition_variable>
+#include <deque>
+#include <exception>
 #include <filesystem>
 #include <map>
+#include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
+#include <thread>
+#include <vector>
 
 #ifdef NELUX_ENABLE_CUDA
 #include <cuda_runtime.h>
@@ -41,6 +48,15 @@ class VideoEncoder
 
     void encodeFrame(torch::Tensor frame);
     void close();
+
+    // Copy audio and/or subtitle streams from `source` into the output
+    // (ffmpeg `-c:a copy -c:s copy`). Must be called before the first
+    // encodeFrame. `start`/`end` (seconds) trim the copied streams; end < 0
+    // means "to end of source". When `allowTranscode` is true, streams whose
+    // codec cannot be copied into the output container are re-encoded to the
+    // container default instead of being dropped.
+    void addPassthrough(const std::string& source, bool audio, bool subtitles,
+                        double start, double end, bool allowTranscode);
     
     // Check if using hardware encoder
     bool isHardwareEncoder() const { return encoder && encoder->isHardwareEncoder(); }
@@ -58,9 +74,85 @@ class VideoEncoder
     cudaStream_t encoderStream = nullptr;
 #endif
     
-    // Reusable CPU frame to avoid allocation churn
+    // Reusable CPU frame to avoid allocation churn (owned by the encode worker
+    // once async encoding starts; only ever touched by one thread at a time).
     nelux::Frame cpuFrame;
-    
+
+    // --- Async encode pipeline (fan-out convert -> in-order submit) ----------
+    // RGB->YUV swscale is single-threaded and dominates the worker (~80% at 4K),
+    // so it is fanned out across K convert workers (mirrors the decoder's
+    // convert pool). Each converts a frame in parallel, tags it with a sequence
+    // number, and drops it in a reorder map. ONE encode thread pulls frames in
+    // sequence order and calls avcodec_send_frame (x264 is a single stateful
+    // context -> submit must stay sequential). GPU/NVENC input skips the convert
+    // workers: the convert is cheap on the GPU, so those jobs go straight to the
+    // submit thread (which does the GPU convert there).
+    void startEncodeWorkersIfNeeded();    // spawns the single submit thread
+    void ensureConvertPipeline();         // lazily spawns convert pool (CPU path only)
+    void stopEncodeWorkers();             // drains all queued frames, then joins
+    void convertWorkerLoop(int workerId);
+    void encodeSubmitLoop();
+    void submitYuvFrame(nelux::Frame* yuv);  // submit thread: make-writable + send + drain
+#ifdef NELUX_ENABLE_CUDA
+    // GPU: wait input-ready, RGB->NV12 on stream, copy into CUDA AVFrame, send.
+    void submitGpuToEncoder(torch::Tensor& gpuTensor, cudaEvent_t readyEvent);
+#endif
+
+    // RGB frame awaiting conversion (CPU path), assigned a target YUV frame.
+    struct ConvertJob
+    {
+        std::vector<uint8_t>* staging = nullptr;  // recycled RGB24 buffer
+        nelux::Frame* yuv = nullptr;              // recycled YUV frame to fill
+        int64_t seq = 0;
+    };
+
+    // A frame ready for the submit thread, in `readyMap` keyed by seq.
+    struct ReadyEntry
+    {
+        nelux::Frame* yuv = nullptr;   // CPU path: already converted, ready to send
+#ifdef NELUX_ENABLE_CUDA
+        torch::Tensor gpuTensor;       // GPU path: converted on the submit thread
+        cudaEvent_t readyEvent = nullptr;
+        bool isGpu = false;
+#endif
+    };
+
+    std::vector<std::thread> convertWorkers;
+    std::thread encodeThread;
+    // One converter (own SwsContext — not thread-safe to share) per convert worker.
+    std::vector<std::unique_ptr<nelux::conversion::IConverter>> converters;
+
+    // Recyclable buffers / frames (sized to cover max frames in flight).
+    std::vector<std::unique_ptr<std::vector<uint8_t>>> stagingPool;
+    std::deque<std::vector<uint8_t>*> freeStaging;
+    std::vector<std::unique_ptr<nelux::Frame>> yuvPool;
+    std::deque<nelux::Frame*> freeYuv;
+
+    std::deque<ConvertJob> convertQueue;     // RGB awaiting convert (CPU path)
+    std::map<int64_t, ReadyEntry> readyMap;  // seq -> ready frame, drained in order
+#ifdef NELUX_ENABLE_CUDA
+    // GPU tensors the submit thread is done with. The submit thread only MOVES
+    // them here (no refcount op, no GIL); the caller frees them at encode_frame
+    // entry while it still holds the GIL. This avoids the submit thread taking
+    // the GIL per frame, which stalled it behind the GIL-heavy host pipeline.
+    std::deque<torch::Tensor> retiredTensors;
+#endif
+    int64_t enqueueSeq = 0;     // caller-assigned, monotonic
+    int64_t nextSubmitSeq = 0;  // submit thread cursor
+    int64_t inFlight = 0;       // admitted but not yet submitted (backpressure)
+
+    std::mutex mu;
+    std::condition_variable cvConvert;  // convert workers wait for convertQueue
+    std::condition_variable cvReady;    // submit thread waits for readyMap[nextSubmitSeq]
+    std::condition_variable cvFree;     // caller waits for in-flight capacity
+
+    int numConvertWorkers = 0;       // resolved at start (<=0 => auto)
+    size_t maxFramesInFlight = 8;    // bounded == backpressure
+    std::exception_ptr workerError;  // first error from any worker, re-raised
+    bool workersStarted = false;     // submit thread up
+    bool convertStarted = false;     // convert pool up (CPU path only)
+    bool stopping = false;
+
     nelux::Encoder::EncodingProperties inferEncodingProperties(
         const std::string& filename, std::optional<std::string> codec,
         std::optional<int> width, std::optional<int> height, std::optional<int> bitRate,

--- a/nelux/_nelux.pyi
+++ b/nelux/_nelux.pyi
@@ -247,6 +247,9 @@ class VideoEncoder:
         before the first encode_frame. When allow_transcode is True, streams
         whose codec cannot be stream-copied into the output container are
         re-encoded to the container default instead of being dropped.
+
+        Only one passthrough source is supported per encoder; a second call
+        raises RuntimeError.
         """
         ...
 

--- a/nelux/_nelux.pyi
+++ b/nelux/_nelux.pyi
@@ -1,4 +1,4 @@
-from typing import List, Literal, Optional, Tuple, Union
+from typing import Dict, List, Literal, Optional, Tuple, Union
 import os
 import torch
 import numpy as np
@@ -212,18 +212,41 @@ class VideoEncoder:
         height: Optional[int] = None,
         bit_rate: Optional[int] = None,
         fps: Optional[float] = None,
-        preset: Optional[int] = None,
+        preset: Optional[Union[int, str]] = None,
         cq: Optional[int] = None,
         pixel_format: Optional[str] = None,
+        options: Optional[Dict[str, str]] = None,
     ) -> None:
         """
         Create a VideoEncoder; pass None for defaults.
+
+        preset accepts an int (mapped per codec) or a str forwarded straight to
+        ffmpeg (e.g. "veryfast", "p4", "medium"). options is a dict of extra
+        AVOption key/value pairs applied after the built-in options.
         """
         ...
 
     def encode_frame(self, frame: torch.Tensor) -> None:
         """
         Encode one video frame HWC, 3-channel, uint8 tensor).
+        """
+        ...
+
+    def add_passthrough(
+        self,
+        source: str,
+        audio: bool = True,
+        subtitles: bool = True,
+        start: float = 0.0,
+        end: Optional[float] = None,
+        allow_transcode: bool = True,
+    ) -> None:
+        """
+        Copy (or transcode) audio/subtitle streams from a source file into the
+        output, with optional [start, end) trim in seconds. Must be called
+        before the first encode_frame. When allow_transcode is True, streams
+        whose codec cannot be stream-copied into the output container are
+        re-encoded to the container default instead of being dropped.
         """
         ...
 

--- a/src/Nelux/FFmpegDelayLoad.cpp
+++ b/src/Nelux/FFmpegDelayLoad.cpp
@@ -15,6 +15,7 @@ static const char* AVCODEC_VERSIONS[] = {"avcodec-62.dll", "avcodec-61.dll", "av
 static const char* AVFORMAT_VERSIONS[] = {"avformat-62.dll", "avformat-61.dll", "avformat-60.dll", nullptr};
 static const char* AVUTIL_VERSIONS[] = {"avutil-60.dll", "avutil-59.dll", "avutil-58.dll", nullptr};
 static const char* SWSCALE_VERSIONS[] = {"swscale-9.dll", "swscale-8.dll", "swscale-7.dll", nullptr};
+static const char* SWRESAMPLE_VERSIONS[] = {"swresample-6.dll", "swresample-5.dll", "swresample-4.dll", nullptr};
 static const char* AVFILTER_VERSIONS[] = {"avfilter-11.dll", "avfilter-10.dll", "avfilter-9.dll", nullptr};
 static const char* AVDEVICE_VERSIONS[] = {"avdevice-62.dll", "avdevice-61.dll", "avdevice-60.dll", nullptr};
 
@@ -29,6 +30,7 @@ static const DllVersionMap DLL_VERSIONS[] = {
     {"avformat", AVFORMAT_VERSIONS},
     {"avutil", AVUTIL_VERSIONS},
     {"swscale", SWSCALE_VERSIONS},
+    {"swresample", SWRESAMPLE_VERSIONS},
     {"avfilter", AVFILTER_VERSIONS},
     {"avdevice", AVDEVICE_VERSIONS},
 };

--- a/src/Nelux/backends/Encoder.cpp
+++ b/src/Nelux/backends/Encoder.cpp
@@ -198,6 +198,12 @@ void Encoder::addInputStreams(const std::string& source, bool wantAudio,
     if (headerWritten)
         throw std::runtime_error(
             "addInputStreams must be called before the first encoded frame");
+    // A second call would append duplicate output streams and overwrite
+    // inputFormatCtx (so pumpPassthrough would only ever read the latest
+    // source). Allow exactly one passthrough source.
+    if (hasPassthrough || inputFormatCtx)
+        throw std::runtime_error(
+            "add_passthrough may only be called once per encoder");
     if (!wantAudio && !wantSubtitles)
         return;
 

--- a/src/Nelux/backends/Encoder.cpp
+++ b/src/Nelux/backends/Encoder.cpp
@@ -266,11 +266,16 @@ void Encoder::addInputStreams(const std::string& source, bool wantAudio,
     inPkt.reset(av_packet_alloc());
 
     // Seek the source near startSec (lands on/before the preceding keyframe;
-    // pumpPassthrough drops the residual packets with pts < startSec).
+    // pumpPassthrough drops the residual packets with pts < startSec). A failed
+    // seek (non-seekable source, etc.) is not fatal: pumpPassthrough still drops
+    // every packet before startSec, so we fall back to reading from the start.
     if (passStartSec > 0.0)
     {
         int64_t ts = static_cast<int64_t>(passStartSec * AV_TIME_BASE);
-        av_seek_frame(ic, -1, ts, AVSEEK_FLAG_BACKWARD);
+        if (av_seek_frame(ic, -1, ts, AVSEEK_FLAG_BACKWARD) < 0)
+            NELUX_WARN("Passthrough seek to {:.3f}s failed; copying from the "
+                       "start and dropping pre-start packets instead.",
+                       passStartSec);
     }
 }
 
@@ -392,7 +397,19 @@ bool Encoder::setupAudioTranscode(AVStream* in)
     ps.enc = std::move(enc);
     ps.swr = swr;
     ps.fifo = fifo;
-    passMap.emplace(in->index, std::move(ps));
+    // emplace can throw (node allocation). PassStream has no destructor, so on
+    // failure the raw swr/fifo would leak — free them explicitly. (On success
+    // they are owned by the map entry and freed in close().)
+    try
+    {
+        passMap.emplace(in->index, std::move(ps));
+    }
+    catch (...)
+    {
+        swr_free(&swr);
+        av_audio_fifo_free(fifo);
+        throw;
+    }
 
     NELUX_INFO("Transcoding audio stream {} -> {}", in->index, encC->name);
     return true;
@@ -539,12 +556,20 @@ void Encoder::encodeAudioFromFifo(PassStream& ps, bool flush)
             op->stream_index = ps.outStream->index;
             av_packet_rescale_ts(op.get(), enc->time_base,
                                  ps.outStream->time_base);
-            av_interleaved_write_frame(formatCtx.get(), op.get());  // resets op
+            if (int wret = av_interleaved_write_frame(formatCtx.get(), op.get());
+                wret < 0)  // resets op
+                NELUX_ERROR("Audio passthrough write failed: {}",
+                            errorToString(wret));
         }
     };
 
     auto sendFrame = [&](int n) {
         AVFrame* ef = av_frame_alloc();
+        if (!ef)
+        {
+            NELUX_ERROR("Audio transcode: failed to allocate frame");
+            return;
+        }
         ef->nb_samples = n;
         ef->format = enc->sample_fmt;
         av_channel_layout_copy(&ef->ch_layout, &enc->ch_layout);
@@ -554,10 +579,19 @@ void Encoder::encodeAudioFromFifo(PassStream& ps, bool flush)
             av_frame_free(&ef);
             return;
         }
-        av_audio_fifo_read(ps.fifo, (void**)ef->data, n);
+        if (int rd = av_audio_fifo_read(ps.fifo, (void**)ef->data, n); rd < n)
+        {
+            // Short read means the FIFO held fewer samples than expected; skip
+            // this frame rather than encode uninitialised tail samples.
+            NELUX_ERROR("Audio transcode: FIFO read {} of {} samples", rd, n);
+            av_frame_free(&ef);
+            return;
+        }
         ef->pts = ps.nextPts;
         ps.nextPts += n;
-        avcodec_send_frame(enc, ef);
+        if (int sret = avcodec_send_frame(enc, ef); sret < 0)
+            NELUX_ERROR("Audio transcode: send_frame failed: {}",
+                        errorToString(sret));
         av_frame_free(&ef);
         drain();
     };

--- a/src/Nelux/backends/Encoder.cpp
+++ b/src/Nelux/backends/Encoder.cpp
@@ -1,9 +1,13 @@
 ﻿#include "Encoder.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
+#include <cstring>
+#include <limits>
 #include <mutex>
 #include <optional>
+#include <vector>
 
 #ifdef _WIN32
 #include <fcntl.h>
@@ -14,8 +18,16 @@
 #endif
 
 extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/audio_fifo.h>
+#include <libavutil/avutil.h>
+#include <libavutil/channel_layout.h>
 #include <libavutil/log.h>
+#include <libavutil/opt.h>
 #include <libavutil/pixdesc.h>
+#include <libavutil/samplefmt.h>
+#include <libswresample/swresample.h>
 }
 
 namespace
@@ -87,7 +99,15 @@ Encoder::Encoder(const std::string& filename, const EncodingProperties& properti
 
 Encoder::~Encoder()
 {
-    close();
+    // close() can now throw (lazy header write); a throwing destructor would
+    // terminate. Swallow here — explicit close() still surfaces errors.
+    try
+    {
+        close();
+    }
+    catch (...)
+    {
+    }
 }
 
 void Encoder::initialize()
@@ -154,9 +174,561 @@ void Encoder::openOutputFile()
         }
     }
 
+    // NOTE: the container header is written lazily by ensureHeaderWritten()
+    // (on the first frame / close), not here. addInputStreams() may register
+    // copied audio/subtitle streams between construction and the first frame,
+    // and all output streams must exist before avformat_write_header.
+}
+
+void Encoder::ensureHeaderWritten()
+{
+    if (headerWritten)
+        return;
     if (avformat_write_header(formatCtx.get(), nullptr) < 0)
     {
         throw std::runtime_error("Error occurred when writing header");
+    }
+    headerWritten = true;
+}
+
+void Encoder::addInputStreams(const std::string& source, bool wantAudio,
+                              bool wantSubtitles, double startSec, double endSec,
+                              bool allowTranscodeArg)
+{
+    if (headerWritten)
+        throw std::runtime_error(
+            "addInputStreams must be called before the first encoded frame");
+    if (!wantAudio && !wantSubtitles)
+        return;
+
+    this->allowTranscode = allowTranscodeArg;
+
+    std::string src = normalizePath(source);
+    AVFormatContext* ic = nullptr;
+    if (avformat_open_input(&ic, src.c_str(), nullptr, nullptr) < 0)
+        throw std::runtime_error("Failed to open passthrough source: " + source);
+    inputFormatCtx.reset(ic);
+
+    if (avformat_find_stream_info(ic, nullptr) < 0)
+        throw std::runtime_error("Failed to read stream info from: " + source);
+
+    for (unsigned i = 0; i < ic->nb_streams; ++i)
+    {
+        AVStream* in = ic->streams[i];
+        const AVMediaType type = in->codecpar->codec_type;
+        const bool take = (type == AVMEDIA_TYPE_AUDIO && wantAudio) ||
+                          (type == AVMEDIA_TYPE_SUBTITLE && wantSubtitles);
+        if (!take)
+            continue;
+
+        // Prefer stream copy when the output container accepts the codec as-is
+        // (e.g. AAC into mp4). Otherwise, if transcoding is allowed, decode +
+        // re-encode to the container's default codec; else skip + warn.
+        const bool copyable = avformat_query_codec(
+            formatCtx->oformat, in->codecpar->codec_id, FF_COMPLIANCE_NORMAL);
+
+        bool ok = false;
+        if (copyable)
+            ok = setupCopyStream(in);
+        else if (allowTranscode && type == AVMEDIA_TYPE_AUDIO)
+            ok = setupAudioTranscode(in);
+        else if (allowTranscode && type == AVMEDIA_TYPE_SUBTITLE)
+            ok = setupSubtitleTranscode(in);
+
+        if (!ok)
+        {
+            const char* cn = avcodec_get_name(in->codecpar->codec_id);
+            NELUX_WARN("Cannot {} {} codec '{}' (source stream {}) into '{}'; "
+                       "skipping.",
+                       copyable ? "copy" : "transcode",
+                       av_get_media_type_string(type), cn ? cn : "?", i,
+                       formatCtx->oformat->name);
+        }
+    }
+
+    if (passMap.empty())
+    {
+        NELUX_WARN("No copyable/transcodable audio/subtitle streams in '{}'.",
+                   source);
+        inputFormatCtx.reset();
+        return;
+    }
+
+    passStartSec = startSec < 0.0 ? 0.0 : startSec;
+    passEndSec = endSec;
+    hasPassthrough = true;
+    inPkt.reset(av_packet_alloc());
+
+    // Seek the source near startSec (lands on/before the preceding keyframe;
+    // pumpPassthrough drops the residual packets with pts < startSec).
+    if (passStartSec > 0.0)
+    {
+        int64_t ts = static_cast<int64_t>(passStartSec * AV_TIME_BASE);
+        av_seek_frame(ic, -1, ts, AVSEEK_FLAG_BACKWARD);
+    }
+}
+
+bool Encoder::setupCopyStream(AVStream* in)
+{
+    AVStream* out = avformat_new_stream(formatCtx.get(), nullptr);
+    if (!out)
+        return false;
+    if (avcodec_parameters_copy(out->codecpar, in->codecpar) < 0)
+        return false;
+    // codec_tag is container-specific; clearing lets the muxer assign one valid
+    // for the output container.
+    out->codecpar->codec_tag = 0;
+    out->time_base = in->time_base;
+
+    PassStream ps;
+    ps.srcIndex = in->index;
+    ps.outStream = out;
+    ps.mode = PassMode::Copy;
+    passMap.emplace(in->index, std::move(ps));
+    return true;
+}
+
+bool Encoder::setupAudioTranscode(AVStream* in)
+{
+    const AVCodec* decC = avcodec_find_decoder(in->codecpar->codec_id);
+    if (!decC)
+        return false;
+    AVCodecContextPtr dec(avcodec_alloc_context3(decC));
+    if (!dec || avcodec_parameters_to_context(dec.get(), in->codecpar) < 0)
+        return false;
+    dec->pkt_timebase = in->time_base;
+    if (avcodec_open2(dec.get(), decC, nullptr) < 0)
+        return false;
+
+    // Pick the container's default audio encoder (mp4 -> aac, webm -> opus...).
+    AVCodecID outId = av_guess_codec(formatCtx->oformat, nullptr,
+                                     filename.c_str(), nullptr,
+                                     AVMEDIA_TYPE_AUDIO);
+    if (outId == AV_CODEC_ID_NONE || !avcodec_find_encoder(outId))
+    {
+        const AVCodecID cands[] = {AV_CODEC_ID_AAC,  AV_CODEC_ID_OPUS,
+                                   AV_CODEC_ID_VORBIS, AV_CODEC_ID_MP3,
+                                   AV_CODEC_ID_AC3,  AV_CODEC_ID_FLAC};
+        outId = AV_CODEC_ID_NONE;
+        for (AVCodecID c : cands)
+        {
+            if (avformat_query_codec(formatCtx->oformat, c, FF_COMPLIANCE_NORMAL) &&
+                avcodec_find_encoder(c))
+            {
+                outId = c;
+                break;
+            }
+        }
+    }
+    const AVCodec* encC = avcodec_find_encoder(outId);
+    if (!encC)
+        return false;
+
+    AVCodecContextPtr enc(avcodec_alloc_context3(encC));
+    if (!enc)
+        return false;
+
+    enc->sample_fmt = (encC->sample_fmts) ? encC->sample_fmts[0]
+                                          : AV_SAMPLE_FMT_FLTP;
+
+    int rate = dec->sample_rate > 0 ? dec->sample_rate : 48000;
+    if (encC->supported_samplerates)
+    {
+        bool found = false;
+        for (int i = 0; encC->supported_samplerates[i]; ++i)
+            if (encC->supported_samplerates[i] == rate) { found = true; break; }
+        if (!found)
+            rate = encC->supported_samplerates[0];
+    }
+    enc->sample_rate = rate;
+
+    if (dec->ch_layout.nb_channels > 0)
+        av_channel_layout_copy(&enc->ch_layout, &dec->ch_layout);
+    else
+        av_channel_layout_default(&enc->ch_layout, 2);
+
+    enc->bit_rate = 64000LL * enc->ch_layout.nb_channels;
+    enc->time_base = AVRational{1, enc->sample_rate};
+    if (formatCtx->oformat->flags & AVFMT_GLOBALHEADER)
+        enc->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+
+    if (avcodec_open2(enc.get(), encC, nullptr) < 0)
+        return false;
+
+    AVStream* out = avformat_new_stream(formatCtx.get(), nullptr);
+    if (!out || avcodec_parameters_from_context(out->codecpar, enc.get()) < 0)
+        return false;
+    out->time_base = enc->time_base;
+
+    SwrContext* swr = nullptr;
+    if (swr_alloc_set_opts2(&swr, &enc->ch_layout, enc->sample_fmt,
+                            enc->sample_rate, &dec->ch_layout, dec->sample_fmt,
+                            dec->sample_rate, 0, nullptr) < 0 ||
+        swr_init(swr) < 0)
+    {
+        if (swr) swr_free(&swr);
+        return false;
+    }
+
+    AVAudioFifo* fifo = av_audio_fifo_alloc(enc->sample_fmt,
+                                            enc->ch_layout.nb_channels, 1);
+    if (!fifo)
+    {
+        swr_free(&swr);
+        return false;
+    }
+
+    PassStream ps;
+    ps.srcIndex = in->index;
+    ps.outStream = out;
+    ps.mode = PassMode::TranscodeAudio;
+    ps.dec = std::move(dec);
+    ps.enc = std::move(enc);
+    ps.swr = swr;
+    ps.fifo = fifo;
+    passMap.emplace(in->index, std::move(ps));
+
+    NELUX_INFO("Transcoding audio stream {} -> {}", in->index, encC->name);
+    return true;
+}
+
+bool Encoder::setupSubtitleTranscode(AVStream* in)
+{
+    // Only text subtitles can be transcoded to a text format. Bitmap subs
+    // (DVD/PGS/DVB) would need OCR — skip those.
+    const AVCodecID sid = in->codecpar->codec_id;
+    const bool textSrc =
+        sid == AV_CODEC_ID_SUBRIP || sid == AV_CODEC_ID_TEXT ||
+        sid == AV_CODEC_ID_ASS || sid == AV_CODEC_ID_SSA ||
+        sid == AV_CODEC_ID_WEBVTT || sid == AV_CODEC_ID_MOV_TEXT;
+    if (!textSrc)
+        return false;
+
+    const AVCodec* decC = avcodec_find_decoder(sid);
+    if (!decC)
+        return false;
+    AVCodecContextPtr dec(avcodec_alloc_context3(decC));
+    if (!dec || avcodec_parameters_to_context(dec.get(), in->codecpar) < 0)
+        return false;
+    if (avcodec_open2(dec.get(), decC, nullptr) < 0)
+        return false;
+
+    // av_guess_codec returns NONE for subtitles on several muxers (e.g. mp4),
+    // so fall back to the first text-subtitle codec the container accepts.
+    AVCodecID outId = av_guess_codec(formatCtx->oformat, nullptr,
+                                     filename.c_str(), nullptr,
+                                     AVMEDIA_TYPE_SUBTITLE);
+    if (outId == AV_CODEC_ID_NONE || !avcodec_find_encoder(outId))
+    {
+        const AVCodecID cands[] = {AV_CODEC_ID_MOV_TEXT, AV_CODEC_ID_WEBVTT,
+                                   AV_CODEC_ID_ASS, AV_CODEC_ID_SUBRIP,
+                                   AV_CODEC_ID_TEXT};
+        outId = AV_CODEC_ID_NONE;
+        for (AVCodecID c : cands)
+        {
+            if (avformat_query_codec(formatCtx->oformat, c, FF_COMPLIANCE_NORMAL) &&
+                avcodec_find_encoder(c))
+            {
+                outId = c;
+                break;
+            }
+        }
+    }
+    const AVCodec* encC = avcodec_find_encoder(outId);
+    if (!encC)
+        return false;
+
+    AVCodecContextPtr enc(avcodec_alloc_context3(encC));
+    if (!enc)
+        return false;
+    enc->time_base = AVRational{1, 1000};  // ms — what text muxers expect
+
+    // ASS/SSA carry a header (styles) the encoder needs.
+    if (dec->subtitle_header && dec->subtitle_header_size > 0)
+    {
+        enc->subtitle_header =
+            (uint8_t*)av_mallocz(dec->subtitle_header_size + 1);
+        if (enc->subtitle_header)
+        {
+            memcpy(enc->subtitle_header, dec->subtitle_header,
+                   dec->subtitle_header_size);
+            enc->subtitle_header_size = dec->subtitle_header_size;
+        }
+    }
+    if (formatCtx->oformat->flags & AVFMT_GLOBALHEADER)
+        enc->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+
+    if (avcodec_open2(enc.get(), encC, nullptr) < 0)
+        return false;
+
+    AVStream* out = avformat_new_stream(formatCtx.get(), nullptr);
+    if (!out || avcodec_parameters_from_context(out->codecpar, enc.get()) < 0)
+        return false;
+    out->time_base = enc->time_base;
+
+    PassStream ps;
+    ps.srcIndex = in->index;
+    ps.outStream = out;
+    ps.mode = PassMode::TranscodeSubtitle;
+    ps.dec = std::move(dec);
+    ps.enc = std::move(enc);
+    passMap.emplace(in->index, std::move(ps));
+
+    NELUX_INFO("Transcoding subtitle stream {} -> {}", in->index, encC->name);
+    return true;
+}
+
+double Encoder::packetTimeSec(const AVPacket* p) const
+{
+    AVStream* in = inputFormatCtx->streams[p->stream_index];
+    int64_t ts = (p->pts != AV_NOPTS_VALUE) ? p->pts : p->dts;
+    if (ts == AV_NOPTS_VALUE)
+        return 0.0;
+    return static_cast<double>(ts) * av_q2d(in->time_base);
+}
+
+void Encoder::writeCopyPacket(PassStream& ps, AVPacket* p)
+{
+    AVStream* in = inputFormatCtx->streams[ps.srcIndex];
+    AVStream* out = ps.outStream;
+
+    // Rebase so startSec maps to t=0, aligning copied audio/subs with video
+    // frame 0. Expressed in the source stream time_base before rescaling.
+    int64_t startOff =
+        passStartSec > 0.0
+            ? av_rescale_q(static_cast<int64_t>(passStartSec * AV_TIME_BASE),
+                           AVRational{1, AV_TIME_BASE}, in->time_base)
+            : 0;
+    if (p->pts != AV_NOPTS_VALUE)
+        p->pts = std::max<int64_t>(0, p->pts - startOff);
+    if (p->dts != AV_NOPTS_VALUE)
+        p->dts = std::max<int64_t>(0, p->dts - startOff);
+
+    p->stream_index = out->index;
+    av_packet_rescale_ts(p, in->time_base, out->time_base);
+    p->pos = -1;
+
+    // Takes ownership of p and resets it on return; do not unref afterwards.
+    if (int ret = av_interleaved_write_frame(formatCtx.get(), p); ret < 0)
+        NELUX_ERROR("Passthrough write failed: {}", errorToString(ret));
+}
+
+void Encoder::encodeAudioFromFifo(PassStream& ps, bool flush)
+{
+    AVCodecContext* enc = ps.enc.get();
+    const int frameSize = enc->frame_size > 0 ? enc->frame_size : 1024;
+
+    AVPacketPtr op(av_packet_alloc());
+    auto drain = [&]() {
+        for (;;)
+        {
+            int r = avcodec_receive_packet(enc, op.get());
+            if (r == AVERROR(EAGAIN) || r == AVERROR_EOF)
+                break;
+            if (r < 0)
+            {
+                NELUX_ERROR("Audio encode failed: {}", errorToString(r));
+                break;
+            }
+            op->stream_index = ps.outStream->index;
+            av_packet_rescale_ts(op.get(), enc->time_base,
+                                 ps.outStream->time_base);
+            av_interleaved_write_frame(formatCtx.get(), op.get());  // resets op
+        }
+    };
+
+    auto sendFrame = [&](int n) {
+        AVFrame* ef = av_frame_alloc();
+        ef->nb_samples = n;
+        ef->format = enc->sample_fmt;
+        av_channel_layout_copy(&ef->ch_layout, &enc->ch_layout);
+        ef->sample_rate = enc->sample_rate;
+        if (av_frame_get_buffer(ef, 0) < 0)
+        {
+            av_frame_free(&ef);
+            return;
+        }
+        av_audio_fifo_read(ps.fifo, (void**)ef->data, n);
+        ef->pts = ps.nextPts;
+        ps.nextPts += n;
+        avcodec_send_frame(enc, ef);
+        av_frame_free(&ef);
+        drain();
+    };
+
+    while (av_audio_fifo_size(ps.fifo) >= frameSize)
+        sendFrame(frameSize);
+
+    if (flush)
+    {
+        int rem = av_audio_fifo_size(ps.fifo);
+        if (rem > 0)
+            sendFrame(rem);
+        avcodec_send_frame(enc, nullptr);  // flush encoder
+        drain();
+    }
+}
+
+void Encoder::transcodeAudioPacket(PassStream& ps, AVPacket* p)
+{
+    AVCodecContext* dec = ps.dec.get();
+    if (avcodec_send_packet(dec, p) < 0)  // p==null => start decoder flush
+        return;
+
+    AVFrame* frame = av_frame_alloc();
+    for (;;)
+    {
+        int r = avcodec_receive_frame(dec, frame);
+        if (r == AVERROR(EAGAIN) || r == AVERROR_EOF)
+            break;
+        if (r < 0)
+        {
+            NELUX_ERROR("Audio decode failed: {}", errorToString(r));
+            break;
+        }
+
+        // Resample the decoded frame into the encoder's format and stage it in
+        // the FIFO (which lets us cut exact encoder-frame-sized chunks).
+        int dstNb = (int)swr_get_out_samples(ps.swr, frame->nb_samples);
+        if (dstNb > 0)
+        {
+            uint8_t** dst = nullptr;
+            if (av_samples_alloc_array_and_samples(
+                    &dst, nullptr, ps.enc->ch_layout.nb_channels, dstNb,
+                    ps.enc->sample_fmt, 0) >= 0)
+            {
+                int conv = swr_convert(ps.swr, dst, dstNb,
+                                       (const uint8_t**)frame->data,
+                                       frame->nb_samples);
+                if (conv > 0)
+                    av_audio_fifo_write(ps.fifo, (void**)dst, conv);
+                if (dst)
+                {
+                    av_freep(&dst[0]);
+                    av_freep(&dst);
+                }
+            }
+        }
+        av_frame_unref(frame);
+        encodeAudioFromFifo(ps, false);
+    }
+    av_frame_free(&frame);
+}
+
+void Encoder::transcodeSubtitlePacket(PassStream& ps, AVPacket* p)
+{
+    if (!p)
+        return;  // text subtitle encoders buffer nothing — no flush needed
+
+    AVSubtitle sub;
+    int got = 0;
+    int ret = avcodec_decode_subtitle2(ps.dec.get(), &sub, &got, p);
+    if (ret < 0 || !got)
+    {
+        if (got)
+            avsubtitle_free(&sub);
+        return;
+    }
+
+    AVStream* in = inputFormatCtx->streams[ps.srcIndex];
+    int64_t startOff =
+        passStartSec > 0.0
+            ? av_rescale_q(static_cast<int64_t>(passStartSec * AV_TIME_BASE),
+                           AVRational{1, AV_TIME_BASE}, in->time_base)
+            : 0;
+
+    std::vector<uint8_t> buf(1 << 16);
+    int size = avcodec_encode_subtitle(ps.enc.get(), buf.data(),
+                                       (int)buf.size(), &sub);
+    avsubtitle_free(&sub);
+    if (size <= 0)
+        return;
+
+    AVPacketPtr op(av_packet_alloc());
+    if (av_new_packet(op.get(), size) < 0)
+        return;
+    memcpy(op->data, buf.data(), size);
+    op->stream_index = ps.outStream->index;
+    int64_t pts =
+        (p->pts != AV_NOPTS_VALUE) ? std::max<int64_t>(0, p->pts - startOff) : 0;
+    op->pts = av_rescale_q(pts, in->time_base, ps.outStream->time_base);
+    op->dts = op->pts;
+    op->duration = av_rescale_q(p->duration, in->time_base,
+                                ps.outStream->time_base);
+    av_interleaved_write_frame(formatCtx.get(), op.get());
+}
+
+void Encoder::flushTranscoders()
+{
+    for (auto& [idx, ps] : passMap)
+    {
+        if (ps.mode == PassMode::TranscodeAudio)
+        {
+            transcodeAudioPacket(ps, nullptr);  // drain decoder
+            encodeAudioFromFifo(ps, true);       // empty FIFO + flush encoder
+        }
+        // Subtitle encoders hold no internal buffer — nothing to flush.
+    }
+}
+
+void Encoder::pumpPassthrough(double uptoSec)
+{
+    if (!hasPassthrough)
+        return;
+
+    AVFormatContext* ic = inputFormatCtx.get();
+    while (true)
+    {
+        if (!hasPending)
+        {
+            if (passDone)
+                return;
+            int ret = av_read_frame(ic, inPkt.get());
+            if (ret < 0)
+            {
+                passDone = true;  // EOF or read error -> nothing more to copy
+                return;
+            }
+            if (passMap.find(inPkt->stream_index) == passMap.end())
+            {
+                av_packet_unref(inPkt.get());  // unmapped stream
+                continue;
+            }
+            double t = packetTimeSec(inPkt.get());
+            if (t < passStartSec)
+            {
+                av_packet_unref(inPkt.get());  // residual pre-start after seek
+                continue;
+            }
+            if (passEndSec >= 0.0 && t >= passEndSec)
+            {
+                av_packet_unref(inPkt.get());
+                passDone = true;  // reached -to
+                return;
+            }
+            hasPending = true;  // inPkt now holds a valid, in-range packet
+        }
+
+        // Hold the pending packet until video has advanced past its time, so
+        // audio/subs stay tightly interleaved with the video track.
+        if (packetTimeSec(inPkt.get()) > uptoSec)
+            return;
+
+        PassStream& ps = passMap.at(inPkt->stream_index);
+        switch (ps.mode)
+        {
+        case PassMode::Copy:
+            writeCopyPacket(ps, inPkt.get());  // consumes (resets) inPkt
+            break;
+        case PassMode::TranscodeAudio:
+            transcodeAudioPacket(ps, inPkt.get());
+            break;
+        case PassMode::TranscodeSubtitle:
+            transcodeSubtitlePacket(ps, inPkt.get());
+            break;
+        }
+        av_packet_unref(inPkt.get());  // no-op if writeCopyPacket already reset
+        hasPending = false;
     }
 }
 
@@ -412,8 +984,14 @@ void Encoder::initVideoStream()
 
         videoCodecCtx->pix_fmt = properties.pixelFormat;
 
-        // Ensure multithreading for software encoders (e.g., libx264)
-        if (codec->capabilities & AV_CODEC_CAP_FRAME_THREADS)
+        // Ensure multithreading for software encoders. FFmpeg's frame-threaded
+        // codecs advertise FRAME_THREADS; libx264/libx265/libvpx manage their
+        // OWN thread pool and advertise OTHER_THREADS instead. Both want
+        // thread_count=0 (auto). Without this, libx264 was left at the default
+        // thread_count=1 -> near single-threaded x264 (much lower CPU AND fps
+        // than ffmpeg-cli's default -threads 0).
+        if (codec->capabilities &
+            (AV_CODEC_CAP_FRAME_THREADS | AV_CODEC_CAP_OTHER_THREADS))
         {
             videoCodecCtx->thread_count = 0; // 0 = auto-detect number of threads
         }
@@ -573,6 +1151,10 @@ bool Encoder::encodeFrame(const Frame& frame)
     if (!videoCodecCtx)
         return false;
 
+    // Header must be written before the first packet; any passthrough streams
+    // were registered via addInputStreams before now.
+    ensureHeaderWritten();
+
     // 1) Optionally check if PTS is unset (or negative).
     // 1) Optionally check if PTS is unset (or negative).
     AVFrame* avf = frame.get();
@@ -665,6 +1247,18 @@ void Encoder::writePacket()
 {
     // ONLY video packets should ever reach this helper;
     // they already have pkt->stream_index == videoStream->index
+
+    // Flush any copied audio/subtitle packets whose time precedes this video
+    // packet, keeping all tracks interleaved as video advances.
+    if (hasPassthrough)
+    {
+        double vt = (pkt->pts != AV_NOPTS_VALUE)
+                        ? static_cast<double>(pkt->pts) *
+                              av_q2d(videoCodecCtx->time_base)
+                        : 0.0;
+        pumpPassthrough(vt);
+    }
+
     av_packet_rescale_ts(pkt.get(), videoCodecCtx->time_base, videoStream->time_base);
     if (int ret = av_interleaved_write_frame(formatCtx.get(), pkt.get()); ret < 0)
     {
@@ -678,6 +1272,10 @@ void Encoder::close()
 {
     if (!formatCtx)
         return;
+
+    // Write the header even if no frame was ever encoded, so the trailer and
+    // any copied streams still produce a valid container.
+    ensureHeaderWritten();
 
     // Flush video
     if (videoCodecCtx)
@@ -708,8 +1306,32 @@ void Encoder::close()
         }
     }
 
+    // Flush remaining copied audio/subtitle packets through endSec before the
+    // trailer (video may have ended before the trimmed audio range did), then
+    // drain any decoders/encoders used for transcoded streams.
+    if (hasPassthrough)
+    {
+        pumpPassthrough(passEndSec >= 0.0 ? passEndSec
+                                          : std::numeric_limits<double>::max());
+        flushTranscoders();
+    }
+
     // Trailer finalizes moov box in .mp4
     av_write_trailer(formatCtx.get());
+
+    // Release per-stream transcode resources (swresample / FIFO are not owned
+    // by the codec context, so free them explicitly; the codec contexts
+    // themselves are freed by their AVCodecContextPtr deleters).
+    for (auto& [idx, ps] : passMap)
+    {
+        if (ps.swr)
+            swr_free(&ps.swr);
+        if (ps.fifo)
+            av_audio_fifo_free(ps.fifo);
+    }
+    passMap.clear();
+    inPkt.reset();
+    inputFormatCtx.reset();
 
     // If not NOFILE, close I/O
     if (!(formatCtx->oformat->flags & AVFMT_NOFILE) && formatCtx->pb)

--- a/src/Nelux/python/Bindings.cpp
+++ b/src/Nelux/python/Bindings.cpp
@@ -395,6 +395,59 @@ Args:
 )doc")
         .def("encode_frame", &nelux::VideoEncoder::encodeFrame, py::arg("frame"),
              "Encode one video frame (H×W×3 torch.uint8 tensor).")
+        .def(
+            "add_passthrough",
+            [](nelux::VideoEncoder& e, const std::string& source, bool audio,
+               bool subtitles, double start, std::optional<double> end,
+               bool allow_transcode)
+            {
+                e.addPassthrough(source, audio, subtitles, start,
+                                 end.value_or(-1.0), allow_transcode);
+            },
+            py::arg("source"), py::arg("audio") = true,
+            py::arg("subtitles") = true, py::arg("start") = 0.0,
+            py::arg("end") = py::none(), py::arg("allow_transcode") = true,
+            R"doc(Copy audio and/or subtitle streams from a source file into the output.
+
+Equivalent to ffmpeg ``-c:a copy -c:s copy`` (stream copy / remux, no
+re-encode). Must be called BEFORE the first ``encode_frame`` — the container
+header is written on the first frame and all streams must exist by then.
+
+The copied streams are packet-gated by ``start``/``end`` (seconds) and rebased
+so ``start`` maps to output t=0, aligning with the first video frame you push.
+Trim is packet-granular (cut at the nearest packet boundary), matching
+``ffmpeg -c:a copy -ss``. You remain responsible for pushing only the video
+frames in the desired range.
+
+Args:
+    source (str): Path to the file to copy audio/subtitle streams from.
+    audio (bool): Copy audio streams. Defaults to True.
+    subtitles (bool): Copy subtitle streams. Defaults to True.
+    start (float): Trim start in seconds (the ``-ss`` value). Defaults to 0.
+    end (float, optional): Trim end in seconds (the ``-to`` value). None =
+        copy through the end of the source.
+    allow_transcode (bool): When True (default), a stream whose codec cannot be
+        stream-copied into the output container is decoded and re-encoded to
+        the container's default codec (audio -> e.g. aac/opus; text subtitles
+        -> e.g. mov_text/webvtt) instead of being dropped. Set False to force
+        copy-only (drop incompatible streams), matching ffmpeg ``-c copy``.
+
+Notes:
+    With allow_transcode=False the output container must accept the source
+    codec for stream copy (AAC into mp4 ok; AC3 into webm not) — incompatible
+    streams are skipped with a warning. With allow_transcode=True they are
+    re-encoded instead. Bitmap subtitles (PGS/DVD/DVB) cannot be turned into
+    text and are always skipped (would require OCR).
+
+Example:
+    >>> enc = nelux.VideoEncoder("out.mp4", codec="libx264", width=3840,
+    ...                          height=2160, fps=23.98, preset="veryfast",
+    ...                          cq=15, pixel_format="yuv420p")
+    >>> enc.add_passthrough("input.mp4", start=0.0, end=10.0)
+    >>> for f in frames:  # push only the 0-10s frames
+    ...     enc.encode_frame(f)
+    >>> enc.close()
+)doc")
         .def("close", &nelux::VideoEncoder::close,
              "Finalize file and flush video streams.")
         .def_property_readonly("is_hardware_encoder",

--- a/src/Nelux/python/Bindings.cpp
+++ b/src/Nelux/python/Bindings.cpp
@@ -439,6 +439,10 @@ Notes:
     re-encoded instead. Bitmap subtitles (PGS/DVD/DVB) cannot be turned into
     text and are always skipped (would require OCR).
 
+    Only one passthrough source is supported per encoder: calling
+    add_passthrough a second time raises RuntimeError. Pass a single source
+    that carries all the audio/subtitle streams you want copied.
+
 Example:
     >>> enc = nelux.VideoEncoder("out.mp4", codec="libx264", width=3840,
     ...                          height=2160, fps=23.98, preset="veryfast",

--- a/src/Nelux/python/VideoEncoder.cpp
+++ b/src/Nelux/python/VideoEncoder.cpp
@@ -454,6 +454,7 @@ void VideoEncoder::convertWorkerLoop(int workerId)
             convertQueue.pop_front();
         }
 
+        bool converted = true;
         try
         {
             // Each YUV frame is recycled; the encoder may still reference a prior
@@ -466,9 +467,22 @@ void VideoEncoder::convertWorkerLoop(int workerId)
         }
         catch (...)
         {
+            converted = false;
             std::lock_guard<std::mutex> lk(mu);
             if (!workerError)
                 workerError = std::current_exception();
+            // Conversion failed: recycle the buffers and do NOT hand a partial
+            // frame to the submit thread (it would encode garbage). The submit
+            // thread observes workerError via cvReady and tears down.
+            freeStaging.push_back(job.staging);
+            freeYuv.push_back(job.yuv);
+            --inFlight;
+        }
+        if (!converted)
+        {
+            cvReady.notify_one();
+            cvFree.notify_all();
+            continue;
         }
 
         {
@@ -503,7 +517,24 @@ void VideoEncoder::encodeSubmitLoop()
                 // Nothing ready for the next slot. Exit only once stopping AND we
                 // have submitted everything admitted; otherwise (e.g. error) bail.
                 if (workerError || (stopping && nextSubmitSeq >= enqueueSeq))
+                {
+                    // Dispose anything still pending so CUDA events and GPU
+                    // tensors don't leak when we exit early on error. (Holding mu.)
+                    for (auto& kv : readyMap)
+                    {
+#ifdef NELUX_ENABLE_CUDA
+                        if (kv.second.readyEvent)
+                            cudaEventDestroy(kv.second.readyEvent);
+                        if (kv.second.gpuTensor.defined())
+                            retiredTensors.push_back(std::move(kv.second.gpuTensor));
+#endif
+                        if (kv.second.yuv)
+                            freeYuv.push_back(kv.second.yuv);
+                    }
+                    readyMap.clear();
+                    inFlight = 0;
                     break;
+                }
                 continue;
             }
             entry = std::move(it->second);
@@ -549,6 +580,16 @@ void VideoEncoder::submitGpuToEncoder(torch::Tensor& gpuTensor, cudaEvent_t read
         deviceIndex = 0;
     cudaSetDevice(deviceIndex);  // bind this worker thread to the tensor's device
 
+    // Destroy the producer-ready event on every exit path (any of the GPU calls
+    // below can throw). Set non-owning to null first so nothing double-frees it.
+    struct EventGuard
+    {
+        cudaEvent_t e;
+        ~EventGuard() { if (e) cudaEventDestroy(e); }
+    } eventGuard{readyEvent};
+    readyEvent = nullptr;
+    const cudaEvent_t producerReady = eventGuard.e;
+
     // Lazy one-time init of the encode stream + GPU converter, owned by the
     // worker thread that exclusively uses them.
     if (!encoderStream)
@@ -587,8 +628,8 @@ void VideoEncoder::submitGpuToEncoder(torch::Tensor& gpuTensor, cudaEvent_t read
 
     // Make the encode stream wait until the producer (decode + dtype ops) has
     // finished writing the tensor, so the convert below never reads stale data.
-    if (readyEvent)
-        cudaStreamWaitEvent(encoderStream, readyEvent, 0);
+    if (producerReady)
+        cudaStreamWaitEvent(encoderStream, producerReady, 0);
 
     // RGB24 -> NV12/YUV on the GPU (writes into the converter's CUDA buffer).
     gpuConverter->convert(
@@ -597,10 +638,7 @@ void VideoEncoder::submitGpuToEncoder(torch::Tensor& gpuTensor, cudaEvent_t read
 
     AVBufferRef* hwFramesCtx = encoder->getHwFramesCtx();
     if (!hwFramesCtx)
-    {
-        if (readyEvent) cudaEventDestroy(readyEvent);
         throw std::runtime_error("NVENC hardware frames context not initialized");
-    }
 
     nelux::Frame hwFrame(hwFramesCtx);
     hwFrame.get()->format = AV_PIX_FMT_CUDA;
@@ -612,10 +650,7 @@ void VideoEncoder::submitGpuToEncoder(torch::Tensor& gpuTensor, cudaEvent_t read
     gpuConverter->copyToCudaFrame(hwFrame.get());
     gpuConverter->synchronize();
 
-    if (readyEvent)
-        cudaEventDestroy(readyEvent);
-
-    encoder->encodeFrame(hwFrame);
+    encoder->encodeFrame(hwFrame);  // eventGuard frees producerReady on return/throw
 }
 #endif
 

--- a/src/Nelux/python/VideoEncoder.cpp
+++ b/src/Nelux/python/VideoEncoder.cpp
@@ -575,13 +575,9 @@ void VideoEncoder::encodeSubmitLoop()
 #ifdef NELUX_ENABLE_CUDA
 void VideoEncoder::submitGpuToEncoder(torch::Tensor& gpuTensor, cudaEvent_t readyEvent)
 {
-    int deviceIndex = gpuTensor.device().index();
-    if (deviceIndex < 0)
-        deviceIndex = 0;
-    cudaSetDevice(deviceIndex);  // bind this worker thread to the tensor's device
-
-    // Destroy the producer-ready event on every exit path (any of the GPU calls
-    // below can throw). Set non-owning to null first so nothing double-frees it.
+    // Destroy the producer-ready event on every exit path (any call below can
+    // throw). Declared first so it also covers a cudaSetDevice failure; the
+    // parameter is nulled so nothing double-frees it.
     struct EventGuard
     {
         cudaEvent_t e;
@@ -589,6 +585,13 @@ void VideoEncoder::submitGpuToEncoder(torch::Tensor& gpuTensor, cudaEvent_t read
     } eventGuard{readyEvent};
     readyEvent = nullptr;
     const cudaEvent_t producerReady = eventGuard.e;
+
+    int deviceIndex = gpuTensor.device().index();
+    if (deviceIndex < 0)
+        deviceIndex = 0;
+    if (cudaError_t cerr = cudaSetDevice(deviceIndex); cerr != cudaSuccess)
+        throw std::runtime_error("Failed to select CUDA device for NVENC encode: " +
+                                 std::string(cudaGetErrorString(cerr)));
 
     // Lazy one-time init of the encode stream + GPU converter, owned by the
     // worker thread that exclusively uses them.

--- a/src/Nelux/python/VideoEncoder.cpp
+++ b/src/Nelux/python/VideoEncoder.cpp
@@ -1,9 +1,14 @@
 ﻿#include "python/VideoEncoder.hpp"
 #include <cctype>
+#include <cstring>
 #include <filesystem>
 #include <stdexcept>
 #include <Factory.hpp>
 #include <cpu/RGBToAuto.hpp>
+
+#ifdef NELUX_ENABLE_CUDA
+#include <c10/cuda/CUDAStream.h>  // c10::cuda::getCurrentCUDAStream
+#endif
 
 extern "C"
 {
@@ -124,22 +129,67 @@ nelux::Encoder::EncodingProperties VideoEncoder::inferEncodingProperties(
     return props;
 }
 
+void VideoEncoder::addPassthrough(const std::string& source, bool audio,
+                                  bool subtitles, double start, double end,
+                                  bool allowTranscode)
+{
+    if (!encoder)
+        throw std::runtime_error("Encoder is not initialized");
+    // The container header is written on the first encodeFrame; copied streams
+    // must be registered before that. workersStarted flips on the first frame.
+    if (workersStarted)
+        throw std::runtime_error(
+            "add_passthrough must be called before the first encode_frame");
+    encoder->addInputStreams(source, audio, subtitles, start, end,
+                             allowTranscode);
+}
+
 void VideoEncoder::encodeFrame(torch::Tensor frame)
 {
     if (!encoder)
         throw std::runtime_error("Encoder is not initialized");
 
+    // Validate input size up front, while the GIL is still held so this raises
+    // as a clean Python exception. encode_frame copies exactly width*height*3
+    // bytes from the tensor; a smaller tensor would read out of bounds in the
+    // staging memcpy / GPU normalize. Reject anything whose element count
+    // doesn't match the configured HWC RGB24 frame.
+    const int64_t expectedElems = static_cast<int64_t>(width) * height * 3;
+    if (frame.numel() != expectedElems)
+        throw std::invalid_argument(
+            "encode_frame: tensor has " + std::to_string(frame.numel()) +
+            " elements, expected " + std::to_string(expectedElems) + " (" +
+            std::to_string(height) + "x" + std::to_string(width) + "x3 HWC RGB)");
+
+#ifdef NELUX_ENABLE_CUDA
+    // Free GPU tensors retired by the submit thread, here while pybind still
+    // holds the GIL (torch CUDA dealloc can need it). Moving this off the submit
+    // thread avoids a per-frame GIL acquire that otherwise stalls it behind the
+    // GIL-heavy host pipeline (TensorRT) and tanks NVENC throughput.
+    {
+        std::deque<torch::Tensor> toFree;
+        {
+            std::lock_guard<std::mutex> lk(mu);
+            toFree.swap(retiredTensors);
+        }
+        toFree.clear();  // destruct under the GIL
+    }
+#endif
+
     py::gil_scoped_release release;
     
 #ifdef NELUX_ENABLE_CUDA
-    // GPU path: When tensor is on CUDA and we're using NVENC
+    // GPU path: tensor already on CUDA and the encoder is NVENC -> keep the
+    // whole pipeline on the GPU (zero-copy). The caller only does the GPU dtype
+    // normalize here, records an event so the worker's stream waits until that
+    // data is ready, then hands the tensor to the encode worker and returns.
+    // The RGB->NV12 convert, device copy, stream sync and avcodec_send_frame all
+    // run on the worker, overlapped with the caller's next decode/inference.
     if (frame.device().is_cuda() && encoder->isHardwareEncoder())
     {
         int deviceIndex = frame.device().index();
         if (deviceIndex < 0)
-        {
             deviceIndex = 0;
-        }
 
         cudaError_t deviceErr = cudaSetDevice(deviceIndex);
         if (deviceErr != cudaSuccess)
@@ -148,18 +198,7 @@ void VideoEncoder::encodeFrame(torch::Tensor frame)
                                      std::string(cudaGetErrorString(deviceErr)));
         }
 
-        if (!encoderStream)
-        {
-            cudaError_t streamErr = cudaStreamCreateWithFlags(&encoderStream,
-                                                              cudaStreamNonBlocking);
-            if (streamErr != cudaSuccess)
-            {
-                throw std::runtime_error("Failed to create NVENC CUDA stream: " +
-                                         std::string(cudaGetErrorString(streamErr)));
-            }
-        }
-
-        // Convert tensor dtype to uint8 if needed (on GPU)
+        // Convert tensor dtype to uint8 if needed (on GPU, on torch's stream).
         if (frame.dtype() == torch::kFloat16 || frame.dtype() == torch::kFloat32)
         {
             frame = (frame.to(torch::kFloat32) * 255.0f).clamp(0, 255).to(torch::kUInt8);
@@ -172,92 +211,55 @@ void VideoEncoder::encodeFrame(torch::Tensor frame)
         {
             frame = frame.to(torch::kUInt8);
         }
-        
         if (!frame.is_contiguous())
-        {
             frame = frame.contiguous();
-        }
-        
-        // Create GPU converter if not exists
-        if (!gpuConverter)
-        {
-            gpuConverter = std::make_unique<nelux::conversion::gpu::RGBToAutoGPUConverter>(
-                width, height, outputPixelFormat, encoderStream);
 
-            int gpuCs;
-            switch (props.colorspace)
+        // Record an event on the tensor's producer stream (torch current stream,
+        // which is where the decode + the dtype ops above ran). The worker makes
+        // its encode stream wait on this so the convert never reads stale data.
+        cudaEvent_t readyEvent = nullptr;
+        if (cudaEventCreateWithFlags(&readyEvent, cudaEventDisableTiming) != cudaSuccess)
+            readyEvent = nullptr;
+        if (readyEvent)
+        {
+            cudaStream_t producerStream =
+                c10::cuda::getCurrentCUDAStream(deviceIndex).stream();
+            cudaEventRecord(readyEvent, producerStream);
+        }
+
+        startEncodeWorkersIfNeeded();
+
+        // GPU jobs skip the convert workers (convert is cheap on the GPU) and go
+        // straight into the reorder map for the submit thread to convert + send.
+        {
+            std::unique_lock<std::mutex> lk(mu);
+            cvFree.wait(lk, [&] {
+                return inFlight < static_cast<int64_t>(maxFramesInFlight) || workerError;
+            });
+            if (workerError)
             {
-            case AVCOL_SPC_BT709:
-                gpuCs = nelux::backends::cuda::ColorSpaceEncode_BT709;
-                break;
-            case AVCOL_SPC_BT2020_NCL:
-            case AVCOL_SPC_BT2020_CL:
-                gpuCs = nelux::backends::cuda::ColorSpaceEncode_BT2020;
-                break;
-            case AVCOL_SPC_BT470BG:
-            case AVCOL_SPC_SMPTE170M:
-                gpuCs = nelux::backends::cuda::ColorSpaceEncode_BT601;
-                break;
-            default:
-                gpuCs = nelux::backends::cuda::ColorSpaceEncode_BT709;
-                break;
+                if (readyEvent) cudaEventDestroy(readyEvent);
+                std::exception_ptr e = workerError;
+                std::rethrow_exception(e);
             }
-            gpuConverter->setColorSpace(gpuCs);
-            gpuConverter->setColorRange(props.colorRange == AVCOL_RANGE_JPEG
-                                            ? nelux::backends::cuda::ColorRangeEncode_Full
-                                            : nelux::backends::cuda::ColorRangeEncode_Limited);
+            ReadyEntry entry;
+            entry.isGpu = true;
+            entry.gpuTensor = frame;     // holds CUDA storage alive until encoded
+            entry.readyEvent = readyEvent;
+            readyMap.emplace(enqueueSeq++, std::move(entry));
+            ++inFlight;
         }
-        
-        // Convert RGB to NV12/YUV on GPU (writes to CUDA buffer)
-        gpuConverter->convert(
-            reinterpret_cast<const uint8_t*>(frame.data_ptr<uint8_t>()),
-            width * 3);  // RGB24 pitch
-
-        // Allocate a CUDA AVFrame from NVENC's hw_frames_ctx (zero-copy path)
-        AVBufferRef* hwFramesCtx = encoder->getHwFramesCtx();
-        if (!hwFramesCtx)
-        {
-            throw std::runtime_error("NVENC hardware frames context not initialized");
-        }
-
-        nelux::Frame hwFrame(hwFramesCtx);
-        hwFrame.get()->format = AV_PIX_FMT_CUDA;
-        hwFrame.get()->width = width;
-        hwFrame.get()->height = height;
-
-        // Copy from converter's CUDA buffer into the CUDA AVFrame (device-to-device)
-        gpuConverter->copyToCudaFrame(hwFrame.get());
-        gpuConverter->synchronize();
-
-        // Send CUDA frame directly to encoder (no CPU upload)
-        encoder->encodeFrame(hwFrame);
+        cvReady.notify_one();
         return;
     }
 #endif
-    
+
     // CPU path (fallback for non-CUDA tensors or software encoders)
-    
-    // Ensure CPU frame is allocated
-    if (!cpuFrame.get()->data[0])
-    {
-        cpuFrame.get()->format = outputPixelFormat;
-        cpuFrame.get()->width = width;
-        cpuFrame.get()->height = height;
-        cpuFrame.allocateBuffer(32);
-    }
-    
-    // Reset PTS because we reuse the frame (MUST happen every time)
-    cpuFrame.get()->pts = AV_NOPTS_VALUE;
-    
-    nelux::Frame& convertedFrame = cpuFrame;
 
-    // Move tensor to CPU if on CUDA
-    if (frame.device().is_cuda())
-    {
-        frame = frame.to(torch::kCPU);
-    }
-
-    // Convert tensor dtype to uint8 if needed
+    // Normalize dtype to uint8 FIRST, on whatever device the tensor is on.
+    // Doing this before any download means a CUDA float tensor is reduced to
+    // uint8 on the GPU and we transfer 1 byte/channel instead of 2/4 — at 4K
+    // that's a 24.8 MB D2H instead of ~99 MB for float32.
     if (frame.dtype() == torch::kFloat16 || frame.dtype() == torch::kFloat32)
     {
         frame = (frame.to(torch::kFloat32) * 255.0f).clamp(0, 255).to(torch::kUInt8);
@@ -284,34 +286,385 @@ void VideoEncoder::encodeFrame(torch::Tensor frame)
         frame = frame.contiguous();
     }
 
-    // All RGB→YUV conversion goes through libswscale. Covers the full pix_fmt
-    // matrix (gray*, 10/12-bit YUV, packed RGB, GBRP, planar 10le, ProRes
-    // targets) and honors props.colorspace / props.colorRange directly.
-    if (!converter)
+    // Hand the frame to the fan-out convert pipeline. The caller pays for ONE
+    // copy of the RGB bytes into a recycled staging buffer; a pool of convert
+    // workers does the (single-threaded, ~80%-of-the-cost) swscale RGB->YUV in
+    // parallel, and one submit thread sends frames to x264 in sequence order.
+    // The staging buffer is plain host memory -> no GIL needed on the workers.
+    startEncodeWorkersIfNeeded();
+    ensureConvertPipeline();   // CPU path needs the swscale convert pool
+
+    const size_t rgbBytes = static_cast<size_t>(width) * height * 3;
+
+    std::vector<uint8_t>* staging = nullptr;
+    nelux::Frame* yuv = nullptr;
+    int64_t seq = 0;
     {
-        converter = std::make_unique<nelux::conversion::cpu::RGBToAutoConverter>(
-            width, height, outputPixelFormat, props.colorspace, props.colorRange);
+        std::unique_lock<std::mutex> lk(mu);
+        // Backpressure: block until there's an in-flight slot AND a free staging
+        // buffer AND a free YUV frame.
+        cvFree.wait(lk, [&] {
+            return (inFlight < static_cast<int64_t>(maxFramesInFlight) &&
+                    !freeStaging.empty() && !freeYuv.empty()) ||
+                   workerError;
+        });
+        if (workerError)
+        {
+            std::exception_ptr e = workerError;
+            std::rethrow_exception(e);
+        }
+        staging = freeStaging.front(); freeStaging.pop_front();
+        yuv = freeYuv.front(); freeYuv.pop_front();
+        seq = enqueueSeq++;
+        ++inFlight;
     }
 
-    // cpuFrame is reused across calls. A software encoder with B-frames /
-    // multithreading keeps a reference to a previously submitted frame, so
-    // overwriting the buffer in place would corrupt an in-flight frame.
-    // av_frame_make_writable does a copy-on-write reallocation only when the
-    // buffer is still referenced.
-    if (av_frame_make_writable(convertedFrame.get()) < 0)
+    staging->resize(rgbBytes);  // no-op after the first frame
+
+    auto recycleOnError = [&]() {
+        std::lock_guard<std::mutex> lk(mu);
+        freeStaging.push_back(staging);
+        freeYuv.push_back(yuv);
+        --inFlight;
+        cvFree.notify_all();
+    };
+
+    // Copy straight into the staging buffer. For a CUDA tensor, do a single
+    // stream-ordered D2H into staging (no intermediate torch CPU tensor).
+    if (frame.device().is_cuda())
     {
-        throw std::runtime_error("Failed to make encoder frame writable");
+#ifdef NELUX_ENABLE_CUDA
+        int dev = frame.device().index();
+        if (dev < 0) dev = 0;
+        cudaStream_t s = c10::cuda::getCurrentCUDAStream(dev).stream();
+        cudaError_t cerr = cudaMemcpyAsync(staging->data(), frame.data_ptr<uint8_t>(),
+                                           rgbBytes, cudaMemcpyDeviceToHost, s);
+        if (cerr == cudaSuccess)
+            cerr = cudaStreamSynchronize(s);
+        if (cerr != cudaSuccess)
+        {
+            recycleOnError();
+            throw std::runtime_error("D2H copy to staging failed: " +
+                                     std::string(cudaGetErrorString(cerr)));
+        }
+#else
+        frame = frame.to(torch::kCPU);
+        std::memcpy(staging->data(), frame.data_ptr<uint8_t>(), rgbBytes);
+#endif
+    }
+    else
+    {
+        std::memcpy(staging->data(), frame.data_ptr<uint8_t>(), rgbBytes);
     }
 
-    // Convert RGB24 → YUV (I420 or NV12)
-    converter->convert(convertedFrame, frame.data_ptr<uint8_t>());
+    {
+        std::lock_guard<std::mutex> lk(mu);
+        convertQueue.push_back(ConvertJob{staging, yuv, seq});
+    }
+    cvConvert.notify_one();
+}
 
-    // Send converted AVFrame to encoder
-    encoder->encodeFrame(convertedFrame);
+void VideoEncoder::startEncodeWorkersIfNeeded()
+{
+    if (workersStarted)
+        return;
+
+    // Resolve convert worker count (used as backpressure depth even for the GPU
+    // path). Default: ~half the cores, clamped [2,6].
+    if (numConvertWorkers <= 0)
+    {
+        unsigned hc = std::thread::hardware_concurrency();
+        int k = (hc > 0) ? static_cast<int>(hc) / 2 : 4;
+        numConvertWorkers = std::clamp(k, 2, 6);
+    }
+    // workers + 2 keeps every convert worker fed (one filling, one draining)
+    // without over-buffering. At 4K each in-flight slot costs ~24.8 MB RGB +
+    // 12.4 MB YUV, so the depth directly sets the pool RAM footprint.
+    maxFramesInFlight = static_cast<size_t>(numConvertWorkers) + 2;
+
+    workersStarted = true;
+    stopping = false;
+    // Only the single submit thread is spawned here. The convert worker pool is
+    // CPU-path-only and spawned lazily (ensureConvertPipeline) on the first
+    // frame that actually needs a CPU swscale — a GPU/NVENC-only encoder never
+    // spawns it and pays nothing for idle convert threads.
+    encodeThread = std::thread([this] { encodeSubmitLoop(); });
+}
+
+void VideoEncoder::ensureConvertPipeline()
+{
+    if (convertStarted)
+        return;
+
+    // Pools sized exactly to the in-flight cap: the caller acquires a staging
+    // buffer + a YUV frame under the same lock as the inFlight bump, so at most
+    // maxFramesInFlight of each are ever checked out at once.
+    const size_t poolSize = maxFramesInFlight;
+    stagingPool.reserve(poolSize);
+    yuvPool.reserve(poolSize);
+    for (size_t i = 0; i < poolSize; ++i)
+    {
+        stagingPool.push_back(std::make_unique<std::vector<uint8_t>>());
+        {
+            std::lock_guard<std::mutex> lk(mu);
+            freeStaging.push_back(stagingPool.back().get());
+        }
+
+        auto f = std::make_unique<nelux::Frame>();
+        f->get()->format = outputPixelFormat;
+        f->get()->width = width;
+        f->get()->height = height;
+        f->allocateBuffer(32);
+        {
+            std::lock_guard<std::mutex> lk(mu);
+            freeYuv.push_back(f.get());
+        }
+        yuvPool.push_back(std::move(f));
+    }
+
+    // One converter (own SwsContext) per convert worker — SwsContext is not
+    // safe to share across threads.
+    converters.reserve(numConvertWorkers);
+    for (int i = 0; i < numConvertWorkers; ++i)
+        converters.push_back(std::make_unique<nelux::conversion::cpu::RGBToAutoConverter>(
+            width, height, outputPixelFormat, props.colorspace, props.colorRange));
+
+    for (int i = 0; i < numConvertWorkers; ++i)
+        convertWorkers.emplace_back([this, i] { convertWorkerLoop(i); });
+
+    convertStarted = true;
+}
+
+void VideoEncoder::convertWorkerLoop(int workerId)
+{
+    nelux::conversion::IConverter* conv = converters[workerId].get();
+    for (;;)
+    {
+        ConvertJob job;
+        {
+            std::unique_lock<std::mutex> lk(mu);
+            cvConvert.wait(lk, [&] { return !convertQueue.empty() || stopping; });
+            if (convertQueue.empty())
+            {
+                if (stopping)
+                    break;       // drained + stopping -> exit
+                continue;
+            }
+            job = convertQueue.front();
+            convertQueue.pop_front();
+        }
+
+        try
+        {
+            // Each YUV frame is recycled; the encoder may still reference a prior
+            // submission (B-frames), so make_writable does a COW realloc when needed.
+            job.yuv->get()->pts = AV_NOPTS_VALUE;
+            if (av_frame_make_writable(job.yuv->get()) < 0)
+                throw std::runtime_error("Failed to make encoder frame writable");
+
+            conv->convert(*job.yuv, job.staging->data());
+        }
+        catch (...)
+        {
+            std::lock_guard<std::mutex> lk(mu);
+            if (!workerError)
+                workerError = std::current_exception();
+        }
+
+        {
+            std::lock_guard<std::mutex> lk(mu);
+            readyMap[job.seq].yuv = job.yuv;       // hand off to the submit thread
+            freeStaging.push_back(job.staging);    // RGB buffer free immediately
+        }
+        cvReady.notify_one();
+        cvFree.notify_one();
+    }
+}
+
+void VideoEncoder::submitYuvFrame(nelux::Frame* yuv)
+{
+    encoder->encodeFrame(*yuv);
+}
+
+void VideoEncoder::encodeSubmitLoop()
+{
+    for (;;)
+    {
+        ReadyEntry entry;
+        {
+            std::unique_lock<std::mutex> lk(mu);
+            cvReady.wait(lk, [&] {
+                return readyMap.count(nextSubmitSeq) || workerError ||
+                       (stopping && nextSubmitSeq >= enqueueSeq);
+            });
+            auto it = readyMap.find(nextSubmitSeq);
+            if (it == readyMap.end())
+            {
+                // Nothing ready for the next slot. Exit only once stopping AND we
+                // have submitted everything admitted; otherwise (e.g. error) bail.
+                if (workerError || (stopping && nextSubmitSeq >= enqueueSeq))
+                    break;
+                continue;
+            }
+            entry = std::move(it->second);
+            readyMap.erase(it);
+        }
+
+        try
+        {
+#ifdef NELUX_ENABLE_CUDA
+            if (entry.isGpu)
+                submitGpuToEncoder(entry.gpuTensor, entry.readyEvent);
+            else
+#endif
+                submitYuvFrame(entry.yuv);
+        }
+        catch (...)
+        {
+            std::lock_guard<std::mutex> lk(mu);
+            if (!workerError)
+                workerError = std::current_exception();
+        }
+
+        {
+            std::lock_guard<std::mutex> lk(mu);
+#ifdef NELUX_ENABLE_CUDA
+            if (entry.gpuTensor.defined())
+                retiredTensors.push_back(std::move(entry.gpuTensor));  // freed by caller under GIL
+#endif
+            if (entry.yuv)
+                freeYuv.push_back(entry.yuv);
+            ++nextSubmitSeq;
+            --inFlight;
+        }
+        cvFree.notify_all();
+    }
+}
+
+#ifdef NELUX_ENABLE_CUDA
+void VideoEncoder::submitGpuToEncoder(torch::Tensor& gpuTensor, cudaEvent_t readyEvent)
+{
+    int deviceIndex = gpuTensor.device().index();
+    if (deviceIndex < 0)
+        deviceIndex = 0;
+    cudaSetDevice(deviceIndex);  // bind this worker thread to the tensor's device
+
+    // Lazy one-time init of the encode stream + GPU converter, owned by the
+    // worker thread that exclusively uses them.
+    if (!encoderStream)
+    {
+        if (cudaStreamCreateWithFlags(&encoderStream, cudaStreamNonBlocking) != cudaSuccess)
+            throw std::runtime_error("Failed to create NVENC CUDA stream");
+    }
+    if (!gpuConverter)
+    {
+        gpuConverter = std::make_unique<nelux::conversion::gpu::RGBToAutoGPUConverter>(
+            width, height, outputPixelFormat, encoderStream);
+
+        int gpuCs;
+        switch (props.colorspace)
+        {
+        case AVCOL_SPC_BT709:
+            gpuCs = nelux::backends::cuda::ColorSpaceEncode_BT709;
+            break;
+        case AVCOL_SPC_BT2020_NCL:
+        case AVCOL_SPC_BT2020_CL:
+            gpuCs = nelux::backends::cuda::ColorSpaceEncode_BT2020;
+            break;
+        case AVCOL_SPC_BT470BG:
+        case AVCOL_SPC_SMPTE170M:
+            gpuCs = nelux::backends::cuda::ColorSpaceEncode_BT601;
+            break;
+        default:
+            gpuCs = nelux::backends::cuda::ColorSpaceEncode_BT709;
+            break;
+        }
+        gpuConverter->setColorSpace(gpuCs);
+        gpuConverter->setColorRange(props.colorRange == AVCOL_RANGE_JPEG
+                                        ? nelux::backends::cuda::ColorRangeEncode_Full
+                                        : nelux::backends::cuda::ColorRangeEncode_Limited);
+    }
+
+    // Make the encode stream wait until the producer (decode + dtype ops) has
+    // finished writing the tensor, so the convert below never reads stale data.
+    if (readyEvent)
+        cudaStreamWaitEvent(encoderStream, readyEvent, 0);
+
+    // RGB24 -> NV12/YUV on the GPU (writes into the converter's CUDA buffer).
+    gpuConverter->convert(
+        reinterpret_cast<const uint8_t*>(gpuTensor.data_ptr<uint8_t>()),
+        width * 3);  // RGB24 pitch
+
+    AVBufferRef* hwFramesCtx = encoder->getHwFramesCtx();
+    if (!hwFramesCtx)
+    {
+        if (readyEvent) cudaEventDestroy(readyEvent);
+        throw std::runtime_error("NVENC hardware frames context not initialized");
+    }
+
+    nelux::Frame hwFrame(hwFramesCtx);
+    hwFrame.get()->format = AV_PIX_FMT_CUDA;
+    hwFrame.get()->width = width;
+    hwFrame.get()->height = height;
+
+    // Device-to-device copy into the CUDA AVFrame, then sync THIS stream (the
+    // worker blocks here, not the caller) before handing the frame to NVENC.
+    gpuConverter->copyToCudaFrame(hwFrame.get());
+    gpuConverter->synchronize();
+
+    if (readyEvent)
+        cudaEventDestroy(readyEvent);
+
+    encoder->encodeFrame(hwFrame);
+}
+#endif
+
+void VideoEncoder::stopEncodeWorkers()
+{
+    if (!workersStarted)
+        return;
+    {
+        std::lock_guard<std::mutex> lk(mu);
+        stopping = true;
+    }
+    cvConvert.notify_all();
+    cvReady.notify_all();
+    cvFree.notify_all();
+
+    auto joinAll = [&] {
+        // Join convert workers FIRST so they drain convertQueue and populate
+        // readyMap for every admitted frame; then the submit thread can finish
+        // sending all of them and exit.
+        for (auto& t : convertWorkers)
+            if (t.joinable())
+                t.join();
+        if (encodeThread.joinable())
+            encodeThread.join();
+    };
+
+    // Release the GIL while joining: the submit thread may need it to free torch
+    // tensors (GPU path); holding it here would deadlock the join.
+    if (PyGILState_Check())
+    {
+        py::gil_scoped_release rel;
+        joinAll();
+    }
+    else
+    {
+        joinAll();
+    }
+
+    convertWorkers.clear();
+    workersStarted = false;
 }
 
 void VideoEncoder::close()
 {
+    // Drain + join the encode workers FIRST so every queued frame is sent to the
+    // codec before we flush. Flushing (encoder->close sends a null frame) must
+    // happen only after the last real frame.
+    stopEncodeWorkers();
+
 #ifdef NELUX_ENABLE_CUDA
     if (gpuConverter)
     {
@@ -333,11 +686,48 @@ void VideoEncoder::close()
     }
 
     converter.reset();
+
+#ifdef NELUX_ENABLE_CUDA
+    // Drain any GPU tensors the submit thread retired but the caller didn't get
+    // to free. close() is normally called from Python (GIL held); guard for the
+    // destructor-at-shutdown path.
+    if (!retiredTensors.empty())
+    {
+        if (PyGILState_Check())
+        {
+            retiredTensors.clear();
+        }
+        else
+        {
+            pybind11::gil_scoped_acquire gil;
+            retiredTensors.clear();
+        }
+    }
+#endif
+
+    // Surface any error the worker hit mid-stream (it kept draining to avoid a
+    // producer deadlock; this is the first place we can throw cleanly).
+    if (workerError)
+    {
+        std::exception_ptr e = workerError;
+        workerError = nullptr;
+        std::rethrow_exception(e);
+    }
 }
 
 VideoEncoder::~VideoEncoder()
 {
-    close();
+    // close() can rethrow a worker error; a throwing destructor would terminate.
+    // The worker is always joined here so no thread outlives the object.
+    try
+    {
+        close();
+    }
+    catch (...)
+    {
+        // Best-effort: ensure the workers are joined even if flush threw.
+        try { stopEncodeWorkers(); } catch (...) {}
+    }
 }
 
 } // namespace nelux

--- a/tests/bench_encode_quality.py
+++ b/tests/bench_encode_quality.py
@@ -68,20 +68,36 @@ def predecode_rgb(src: str, n: int, w: int, h: int, out: Path):
 
 
 def encode_via_nelux(rgb_raw: Path, n: int, w: int, h: int, codec: str,
-                     pix_fmt: str, extra_kw: dict, out: Path, hw: bool):
-    """Read rgb_raw frames, encode via nelux to out."""
+                     pix_fmt: str, extra_kw: dict, out: Path, hw: bool) -> float:
+    """Read rgb_raw frames, encode via nelux to out. Returns encode-only seconds.
+
+    Tensor construction (byte-slicing + torch marshaling) is done BEFORE the
+    timer, mirroring encode_via_ffmpeg, which reads raw bytes in a subprocess
+    with no Python per-frame overhead. Timing only the encode loop makes the
+    nelux-vs-ffmpeg comparison apples-to-apples.
+    """
     import torch, nelux
     from nelux import VideoEncoder
     raw = rgb_raw.read_bytes()
     fb = h * w * 3
-    enc_kwargs = dict(codec=codec, width=w, height=h, fps=30.0, pixel_format=pix_fmt)
-    enc_kwargs.update(extra_kw)
-    enc = VideoEncoder(str(out), **enc_kwargs)
+
+    # Pre-build all frame tensors (NOT timed).
+    frames = []
     for i in range(n):
         chunk = raw[i*fb : (i+1)*fb]
         t = torch.frombuffer(bytearray(chunk), dtype=torch.uint8).reshape(h, w, 3).contiguous()
+        frames.append(t)
+
+    enc_kwargs = dict(codec=codec, width=w, height=h, fps=30.0, pixel_format=pix_fmt)
+    enc_kwargs.update(extra_kw)
+    enc = VideoEncoder(str(out), **enc_kwargs)
+
+    # Time only the encode loop + flush.
+    t0 = time.perf_counter()
+    for t in frames:
         enc.encode_frame(t)
     enc.close()
+    return time.perf_counter() - t0
 
 
 def encode_via_ffmpeg(rgb_raw: Path, n: int, w: int, h: int, codec: str,
@@ -161,10 +177,9 @@ def main():
 
         rec = {"codec": codec, "pix_fmt": pix_fmt, "hardware": hw}
         try:
-            t0 = time.perf_counter()
-            encode_via_nelux(rgb_ref, args.frames, args.width, args.height,
-                             codec, pix_fmt, nx_kw, nx_out, hw)
-            rec["nx_encode_s"] = time.perf_counter() - t0
+            rec["nx_encode_s"] = encode_via_nelux(
+                rgb_ref, args.frames, args.width, args.height,
+                codec, pix_fmt, nx_kw, nx_out, hw)
 
             t0 = time.perf_counter()
             encode_via_ffmpeg(rgb_ref, args.frames, args.width, args.height,
@@ -188,7 +203,7 @@ def main():
                 rec["psnr_delta"] = nx["psnr"] - ff["psnr"]
                 rec["vmaf_delta"] = (nx.get("vmaf") or 0) - (ff.get("vmaf") or 0)
                 verdict = "PASS" if rec["psnr_delta"] >= -0.5 else "FAIL"
-                print(f"  Δ vs ffmpeg ref: PSNR {rec['psnr_delta']:+.2f} dB  VMAF {rec['vmaf_delta']:+.2f}  → {verdict}")
+                print(f"  delta vs ffmpeg ref: PSNR {rec['psnr_delta']:+.2f} dB  VMAF {rec['vmaf_delta']:+.2f}  -> {verdict}")
         except subprocess.CalledProcessError as e:
             rec["error"] = f"subprocess: {e.stderr[-300:] if e.stderr else e}"
             print(f"  ERROR: {rec['error']}")

--- a/tests/bench_preset_size.py
+++ b/tests/bench_preset_size.py
@@ -1,0 +1,105 @@
+"""x264 preset sanity check: do presets actually take effect in nelux?
+
+Encodes the same N frames with libx264 under every x264 preset and records the
+output file size. Run in two rate-control modes:
+  - crf : constant quality (cq=23). At fixed quality, slower presets compress
+          better -> smaller files. This is the clean signal that presets work.
+  - abr : fixed bitrate (4 Mbps). Over a short clip rate control hasn't fully
+          converged, so size still wiggles per preset.
+
+A monotonic-ish shrink in crf mode (and any spread at all) proves the preset
+string is reaching the encoder rather than being silently ignored.
+"""
+from __future__ import annotations
+import argparse, json, os, shutil, subprocess, sys, tempfile, time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent))
+FFBIN = HERE.parent / "external" / "ffmpeg" / "bin"
+if FFBIN.exists() and hasattr(os, "add_dll_directory"):
+    os.add_dll_directory(str(FFBIN))
+FFMPEG = str(FFBIN / "ffmpeg.exe") if (FFBIN / "ffmpeg.exe").exists() else (shutil.which("ffmpeg") or "ffmpeg")
+
+PRESETS = ["ultrafast", "superfast", "veryfast", "faster", "fast",
+           "medium", "slow", "slower", "veryslow"]
+
+
+def predecode_rgb(src: str, n: int, w: int, h: int, out: Path):
+    cmd = [FFMPEG, "-hide_banner", "-loglevel", "error", "-i", src,
+           "-vf", f"scale={w}:{h},format=rgb24", "-frames:v", str(n),
+           "-f", "rawvideo", str(out)]
+    subprocess.run(cmd, check=True)
+
+
+def encode(rgb_raw: Path, n: int, w: int, h: int, preset: str,
+           mode: str, out: Path) -> float:
+    import torch
+    from nelux import VideoEncoder
+    raw = rgb_raw.read_bytes()
+    fb = h * w * 3
+    frames = []
+    for i in range(n):
+        chunk = raw[i*fb:(i+1)*fb]
+        t = torch.frombuffer(bytearray(chunk), dtype=torch.uint8).reshape(h, w, 3).contiguous()
+        frames.append(t)
+
+    kw = dict(codec="libx264", width=w, height=h, fps=30.0,
+              pixel_format="yuv420p", preset=preset)
+    if mode == "crf":
+        kw["cq"] = 23
+    else:  # abr
+        kw["bit_rate"] = 4_000_000
+
+    enc = VideoEncoder(str(out), **kw)
+    t0 = time.perf_counter()
+    for t in frames:
+        enc.encode_frame(t)
+    enc.close()
+    return time.perf_counter() - t0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--src", default=str(HERE / "data" / "BigBuckBunny.mp4"))
+    ap.add_argument("--frames", type=int, default=5)
+    ap.add_argument("--width", type=int, default=1280)
+    ap.add_argument("--height", type=int, default=720)
+    args = ap.parse_args()
+
+    workdir = Path(tempfile.mkdtemp(prefix="nelux_preset_"))
+    print(f"workdir: {workdir}")
+    rgb_ref = workdir / "src_rgb.raw"
+    predecode_rgb(args.src, args.frames, args.width, args.height, rgb_ref)
+    actual = rgb_ref.stat().st_size
+    fb = args.width * args.height * 3
+    if actual < args.frames * fb:
+        args.frames = actual // fb
+        print(f"  (source shorter; trimming to {args.frames} frames)")
+
+    results = {}
+    for mode in ("crf", "abr"):
+        print(f"\n=== mode={mode} ({args.frames} frames, {args.width}x{args.height}) ===")
+        print(f"{'preset':<11} {'size_bytes':>12} {'enc_s':>8}")
+        rows = []
+        for p in PRESETS:
+            out = workdir / f"x264_{mode}_{p}.mp4"
+            secs = encode(rgb_ref, args.frames, args.width, args.height, p, mode, out)
+            sz = out.stat().st_size
+            rows.append({"preset": p, "size_bytes": sz, "enc_s": round(secs, 3)})
+            print(f"{p:<11} {sz:>12} {secs:>8.3f}")
+        sizes = [r["size_bytes"] for r in rows]
+        spread = max(sizes) - min(sizes)
+        distinct = len(set(sizes))
+        print(f"  spread={spread} bytes  distinct_sizes={distinct}/{len(sizes)}  "
+              f"-> {'PRESETS EFFECTIVE' if distinct > 1 else 'NO EFFECT (all identical!)'}")
+        results[mode] = {"rows": rows, "spread_bytes": spread, "distinct_sizes": distinct}
+
+    out_json = HERE / "output" / "preset_size.json"
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(json.dumps(results, indent=2))
+    print(f"\nWrote {out_json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/bench_workflow.py
+++ b/tests/bench_workflow.py
@@ -1,0 +1,304 @@
+"""Realistic pipeline bench: decode -> inference(stub) -> encode.
+
+Mirrors a streaming inference workload: each frame is decoded, passed through
+a fake model (time.sleep), then encoded. Encode backend is either:
+  - nelux   : VideoEncoder.encode_frame(tensor) in-process
+  - ffmpeg  : a SINGLE persistent ffmpeg subprocess (Popen) reading rawvideo
+              rgb24 on stdin. Spawned once, so process/CUDA/NVENC startup is
+              amortized across the whole stream -- the fair comparison.
+
+Both backends are fed the identical decoded frames at the identical cadence
+(inference sleep between frames). Decode is done by nelux for both, so the
+only thing that differs is the encode path.
+
+CPU% and RAM are sampled in a background thread over the whole pipeline,
+INCLUDING the ffmpeg child process (psutil children) so the subprocess cost
+is counted, not hidden.
+
+Usage:
+  python bench_workflow.py --src data/BigBuckBunny.mp4 --frames 300 \
+      --codec h264_nvenc --inference-ms 1.0
+"""
+from __future__ import annotations
+import argparse, json, os, shutil, statistics, subprocess, sys, threading, time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent))
+FFBIN = HERE.parent / "external" / "ffmpeg" / "bin"
+if FFBIN.exists() and hasattr(os, "add_dll_directory"):
+    os.add_dll_directory(str(FFBIN))
+FFMPEG = str(FFBIN / "ffmpeg.exe") if (FFBIN / "ffmpeg.exe").exists() else (shutil.which("ffmpeg") or "ffmpeg")
+
+# nelux codec -> (ffmpeg -c:v name, extra ffmpeg args). Settings matched to the
+# nelux encoder kwargs below (4 Mbps, default preset, yuv420p).
+CODECS = {
+    "libx264":    ("libx264",    ["-b:v", "4M"]),
+    "libx265":    ("libx265",    ["-b:v", "4M", "-x265-params", "log-level=error"]),
+    "libsvtav1":  ("libsvtav1",  ["-b:v", "4M"]),
+    "h264_nvenc": ("h264_nvenc", ["-b:v", "4M"]),
+    "hevc_nvenc": ("hevc_nvenc", ["-b:v", "4M"]),
+}
+
+
+class ResourceSampler:
+    """Samples summed CPU% and RSS of this process + all children every 50ms."""
+    def __init__(self):
+        import psutil
+        self.psutil = psutil
+        self.proc = psutil.Process(os.getpid())
+        self.cpu_samples: list[float] = []
+        self.rss_samples: list[float] = []
+        self._stop = threading.Event()
+        self._th: threading.Thread | None = None
+        # Persistent Process objects keyed by pid. psutil computes cpu_percent as
+        # the delta since the LAST cpu_percent() call ON THE SAME OBJECT, so we
+        # MUST reuse objects across samples — re-fetching children() each tick
+        # yields fresh objects that always report 0.0 (silently undercounting
+        # the ffmpeg child).
+        self._cache: dict[int, object] = {self.proc.pid: self.proc}
+
+    def _refresh(self):
+        """Return live cached procs; prime newly-seen children (first read=0.0)."""
+        try:
+            current = {p.pid: p for p in self.proc.children(recursive=True)}
+        except self.psutil.Error:
+            current = {}
+        current[self.proc.pid] = self.proc
+        # Add + prime new pids.
+        for pid, p in current.items():
+            if pid not in self._cache:
+                try: p.cpu_percent(interval=None)  # prime baseline
+                except self.psutil.Error: pass
+                self._cache[pid] = p
+        # Drop dead pids.
+        for pid in [pid for pid in self._cache if pid not in current]:
+            del self._cache[pid]
+        return list(self._cache.values())
+
+    def _run(self):
+        self.proc.cpu_percent(interval=None)  # prime self
+        while not self._stop.is_set():
+            cpu = 0.0
+            rss = 0.0
+            for p in self._refresh():
+                try:
+                    cpu += p.cpu_percent(interval=None)
+                    rss += p.memory_info().rss
+                except self.psutil.Error:
+                    pass
+            self.cpu_samples.append(cpu)
+            self.rss_samples.append(rss)
+            time.sleep(0.05)
+
+    def __enter__(self):
+        self._th = threading.Thread(target=self._run, daemon=True)
+        self._th.start()
+        return self
+
+    def __exit__(self, *a):
+        self._stop.set()
+        if self._th:
+            self._th.join(timeout=2)
+
+    def summary(self) -> dict:
+        # cpu_percent is normalized to a single core by psutil; >100% = multicore.
+        return {
+            "cpu_avg_pct": statistics.mean(self.cpu_samples) if self.cpu_samples else 0.0,
+            "cpu_peak_pct": max(self.cpu_samples) if self.cpu_samples else 0.0,
+            "rss_avg_mb": (statistics.mean(self.rss_samples) / 1e6) if self.rss_samples else 0.0,
+            "rss_peak_mb": (max(self.rss_samples) / 1e6) if self.rss_samples else 0.0,
+        }
+
+
+def _to_cpu_bytes(t):
+    """Tensor -> raw bytes on CPU (downloads from GPU if needed)."""
+    return (t.cpu() if t.is_cuda else t).numpy().tobytes()
+
+
+def decode_frames(src: str, n: int, accel: str = "cpu"):
+    """Decode up to n RGB frames to a list of contiguous uint8 HWC tensors.
+
+    accel="cpu": frames land on CPU. accel="nvdec": frames stay on GPU (CUDA
+    tensors) so the nelux encoder can take the zero-copy nvdec->nvenc path.
+    """
+    import torch  # must precede nelux
+    import nelux
+    r = nelux.VideoReader(src, backend="pytorch", decode_accelerator=accel)
+    w, h, fps = r.width, r.height, float(r.fps)
+    frames = []
+    for _ in range(n):
+        try:
+            t = r.read_frame()
+        except (StopIteration, RuntimeError):
+            break
+        if t is None:
+            break
+        t = t.contiguous()
+        # nvdec hands out tensors backed by a FIXED decoder surface pool. Holding
+        # every frame would exhaust the pool and deadlock decode, so copy GPU
+        # frames into independent torch-owned CUDA memory (cheap d2d clone).
+        if t.is_cuda:
+            t = t.clone()
+        frames.append(t)
+    del r
+    return frames, w, h, fps
+
+
+def run_nelux(frames, w, h, fps, codec, out_path, infer_s):
+    from nelux import VideoEncoder
+    enc = VideoEncoder(str(out_path), codec=codec, width=w, height=h,
+                       fps=fps, pixel_format="yuv420p", bit_rate=4_000_000)
+    t0 = time.perf_counter()
+    for f in frames:
+        time.sleep(infer_s)          # inference stub
+        enc.encode_frame(f)
+    enc.close()
+    return time.perf_counter() - t0
+
+
+def run_ffmpeg(frames, w, h, fps, ff_codec, ff_args, out_path, infer_s):
+    cmd = [FFMPEG, "-y", "-hide_banner", "-loglevel", "error",
+           "-f", "rawvideo", "-pix_fmt", "rgb24", "-s", f"{w}x{h}",
+           "-r", str(int(round(fps))), "-i", "-",
+           "-c:v", ff_codec, "-pix_fmt", "yuv420p", *ff_args, str(out_path)]
+    # Spawn ONCE (warm); startup amortized over the whole stream.
+    proc = subprocess.Popen(cmd, stdin=subprocess.PIPE,
+                            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    t0 = time.perf_counter()
+    assert proc.stdin is not None
+    for f in frames:
+        time.sleep(infer_s)          # inference stub
+        # ffmpeg-over-stdin needs CPU bytes; if frames are on GPU this download
+        # is the cost the pipe approach pays that nelux's zero-copy path avoids.
+        proc.stdin.write(_to_cpu_bytes(f))
+    proc.stdin.close()
+    proc.wait()
+    return time.perf_counter() - t0
+
+
+def write_reference_raw(frames, out: Path):
+    """Dump the exact frames fed to the encoders as one rgb24 raw file."""
+    with open(out, "wb") as f:
+        for t in frames:
+            f.write(_to_cpu_bytes(t))
+
+
+def decode_to_rgb_raw(src: Path, n: int, w: int, h: int, out: Path):
+    """Decode an encoded file back to rgb24 raw at exactly w x h."""
+    cmd = [FFMPEG, "-hide_banner", "-loglevel", "error", "-i", str(src),
+           "-vf", f"scale={w}:{h},format=rgb24", "-frames:v", str(n),
+           "-f", "rawvideo", str(out)]
+    subprocess.run(cmd, check=True)
+
+
+def quality_vs_ref(test_raw: Path, ref_raw: Path, w: int, h: int, n: int) -> dict:
+    """PSNR / SSIM / VMAF of test_raw vs ref_raw via ffmpeg lavfi."""
+    import re
+    def metric(args: str, pattern: str):
+        cmd = [FFMPEG, "-hide_banner", "-nostats", "-loglevel", "info",
+               "-f", "rawvideo", "-pix_fmt", "rgb24", "-s", f"{w}x{h}", "-r", "30",
+               "-i", str(test_raw),
+               "-f", "rawvideo", "-pix_fmt", "rgb24", "-s", f"{w}x{h}", "-r", "30",
+               "-i", str(ref_raw),
+               "-frames:v", str(n), "-lavfi", args, "-f", "null", "-"]
+        r = subprocess.run(cmd, capture_output=True, text=True)
+        m = re.search(pattern, r.stderr)
+        if not m:
+            return None
+        g = m.group(1)
+        try:
+            return float(g)
+        except ValueError:
+            return float("inf") if g.strip() == "inf" else None
+    return {
+        "psnr": metric("psnr", r"average:\s*(inf|[\d.]+)"),
+        "ssim": metric("ssim", r"All:\s*([\d.]+)"),
+        "vmaf": metric("libvmaf", r"VMAF score: ([\d.]+)"),
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--src", default=str(HERE / "data" / "BigBuckBunny.mp4"))
+    ap.add_argument("--frames", type=int, default=300)
+    ap.add_argument("--codec", default="h264_nvenc", choices=list(CODECS))
+    ap.add_argument("--inference-ms", type=float, default=1.0)
+    ap.add_argument("--decode", choices=["cpu", "nvdec"], default="cpu",
+                    help="nvdec keeps frames on GPU -> exercises nelux zero-copy nvdec->nvenc")
+    args = ap.parse_args()
+    infer_s = args.inference_ms / 1000.0
+
+    import tempfile
+    workdir = Path(tempfile.mkdtemp(prefix="nelux_wf_"))
+    print(f"workdir: {workdir}")
+    print(f"decoding up to {args.frames} frames from {Path(args.src).name} (decode={args.decode}) ...")
+    frames, w, h, fps = decode_frames(args.src, args.frames, args.decode)
+    n = len(frames)
+    on_gpu = bool(frames) and frames[0].is_cuda
+    print(f"decoded {n} frames @ {w}x{h} {fps:.1f}fps | on_gpu={on_gpu} | "
+          f"inference stub = {args.inference_ms}ms/frame")
+    floor_s = n * infer_s
+    print(f"inference floor (n*sleep) = {floor_s:.3f}s\n")
+
+    # Reference = exact frames handed to the encoders (post-decode input).
+    ref_raw = workdir / "reference.raw"
+    write_reference_raw(frames, ref_raw)
+
+    ff_codec, ff_args = CODECS[args.codec]
+    results = {}
+    out_paths = {}
+
+    for backend in ("nelux", "ffmpeg"):
+        out = workdir / f"{backend}_{args.codec}.mp4"
+        out_paths[backend] = out
+        with ResourceSampler() as s:
+            if backend == "nelux":
+                dur = run_nelux(frames, w, h, fps, args.codec, out, infer_s)
+            else:
+                dur = run_ffmpeg(frames, w, h, fps, ff_codec, ff_args, out, infer_s)
+        res = s.summary()
+        res["wall_s"] = dur
+        res["fps"] = n / dur if dur > 0 else 0.0
+        res["over_floor_s"] = dur - floor_s   # pipeline cost above pure inference
+        res["out_kb"] = out.stat().st_size / 1024 if out.exists() else 0.0
+        results[backend] = res
+        print(f"[{backend:>6}] wall={res['wall_s']:.3f}s ({res['fps']:.1f} fps)  "
+              f"over_floor={res['over_floor_s']:.3f}s  "
+              f"cpu_avg={res['cpu_avg_pct']:.0f}% peak={res['cpu_peak_pct']:.0f}%  "
+              f"rss_avg={res['rss_avg_mb']:.0f}MB peak={res['rss_peak_mb']:.0f}MB  "
+              f"out={res['out_kb']:.0f}KB")
+
+    # Quality: decode each output back to RGB, compare vs the reference input
+    # and against each other. Confirms both encoders preserve the input equally.
+    print("\nquality (decode outputs, compare vs input + each other):")
+    nx_dec = workdir / "nx_dec.raw"
+    ff_dec = workdir / "ff_dec.raw"
+    decode_to_rgb_raw(out_paths["nelux"], n, w, h, nx_dec)
+    decode_to_rgb_raw(out_paths["ffmpeg"], n, w, h, ff_dec)
+    q_nx = quality_vs_ref(nx_dec, ref_raw, w, h, n)
+    q_ff = quality_vs_ref(ff_dec, ref_raw, w, h, n)
+    q_cross = quality_vs_ref(nx_dec, ff_dec, w, h, n)
+    results["nelux"]["vs_input"] = q_nx
+    results["ffmpeg"]["vs_input"] = q_ff
+    results["nelux_vs_ffmpeg"] = q_cross
+
+    def fmt(q):
+        return f"PSNR={q['psnr']} SSIM={q['ssim']} VMAF={q['vmaf']}"
+    print(f"  nelux  vs input : {fmt(q_nx)}")
+    print(f"  ffmpeg vs input : {fmt(q_ff)}")
+    print(f"  nelux  vs ffmpeg: {fmt(q_cross)}")
+    if q_nx["psnr"] is not None and q_ff["psnr"] is not None:
+        print(f"  PSNR delta (nelux - ffmpeg vs input): {q_nx['psnr'] - q_ff['psnr']:+.3f} dB")
+
+    out_json = HERE / "output" / "workflow_bench.json"
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"src": args.src, "codec": args.codec, "frames": n,
+               "width": w, "height": h, "fps": fps,
+               "inference_ms": args.inference_ms, "results": results}
+    out_json.write_text(json.dumps(payload, indent=2))
+    print(f"\nWrote {out_json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_async_encode_pipeline.py
+++ b/tests/test_async_encode_pipeline.py
@@ -1,0 +1,283 @@
+"""
+Async encode pipeline integrity tests (fan-out convert -> in-order submit).
+
+These exercise the v0.11.x async encoder: a pool of convert workers does the
+RGB->YUV swscale in parallel and a single submit thread sends frames to the
+codec in sequence order. The reorder map, backpressure and clean-teardown paths
+are the risky surface, so the tests focus on:
+
+  * frame-count integrity  - every submitted frame reaches the container
+  * frame-order integrity  - the reorder map preserves submission order
+  * PSNR floor             - the convert + encode round-trip stays faithful
+  * error propagation      - a bad frame raises and the pipeline tears down clean
+  * nvdec -> nvenc smoke    - realistic decode -> encode wiring end to end
+
+CPU (software encoder) variants run everywhere. CUDA -> NVENC variants are
+skipped cleanly when no GPU / NVENC encoder is present.
+
+Frame counts are chosen above the in-flight cap (numConvertWorkers + 2, <= 8) so
+the backpressure + reorder logic is actually stressed rather than trivially
+satisfied.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import torch
+
+import nelux
+from nelux import VideoEncoder, VideoReader
+
+
+HERE = Path(__file__).resolve().parent
+OUT_DIR = HERE / "output" / "async_pipeline"
+OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _find_ffprobe() -> str | None:
+    bundled = HERE.parent / "external" / "ffmpeg" / "bin" / "ffprobe.exe"
+    return str(bundled) if bundled.exists() else shutil.which("ffprobe")
+
+
+_FFPROBE = _find_ffprobe()
+
+# Above the in-flight cap so the reorder/backpressure paths are exercised.
+N_FRAMES = 24
+WIDTH, HEIGHT = 256, 144
+FPS = 30.0
+
+_ENCODERS = {e["name"] for e in nelux.get_available_encoders()}
+_HAS_NVENC = "h264_nvenc" in _ENCODERS
+_HAS_CUDA = torch.cuda.is_available()
+
+cuda_nvenc = pytest.mark.skipif(
+    not (_HAS_CUDA and _HAS_NVENC),
+    reason="requires CUDA + h264_nvenc",
+)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+def _solid_frame(value: int, device: str = "cpu") -> torch.Tensor:
+    """HWC RGB24 frame filled with a single value (R==G==B)."""
+    return torch.full((HEIGHT, WIDTH, 3), value, dtype=torch.uint8, device=device)
+
+
+def _gradient_frame(device: str = "cpu") -> torch.Tensor:
+    """Static smooth grayscale gradient (R==G==B) so chroma subsampling is lossless."""
+    xs = torch.linspace(16, 235, WIDTH)
+    ys = torch.linspace(16, 235, HEIGHT)
+    grid = ((xs[None, :] + ys[:, None]) * 0.5).clamp(0, 255).to(torch.uint8)
+    frame = grid.unsqueeze(-1).expand(HEIGHT, WIDTH, 3).contiguous()
+    return frame.to(device) if device != "cpu" else frame
+
+
+def _decode_all(path: Path) -> list:
+    """Decode every frame back as CPU uint8 HWC tensors.
+
+    Note: an mp4 with B-frames carries an edit list that trims the leading
+    encoder-delay, so a decoder (ffmpeg and nelux alike) may replay one fewer
+    frame than was encoded. Use _packet_count for an exact "frames encoded"
+    measure; use this only where the content (not the exact count) is checked.
+    """
+    return list(VideoReader(str(path)))
+
+
+def _packet_count(path: Path) -> int:
+    """Authoritative count of encoded video packets via ffprobe (= frames in)."""
+    if _FFPROBE is None:
+        pytest.skip("ffprobe not available for packet count")
+    out = subprocess.run(
+        [_FFPROBE, "-v", "error", "-select_streams", "v:0",
+         "-count_packets", "-show_entries", "stream=nb_read_packets",
+         "-of", "json", str(path)],
+        capture_output=True, text=True, check=True,
+    )
+    return int(json.loads(out.stdout)["streams"][0]["nb_read_packets"])
+
+
+def _psnr(a: torch.Tensor, b: torch.Tensor) -> float:
+    mse = torch.mean((a.float() - b.float()) ** 2).item()
+    if mse <= 1e-9:
+        return 99.0
+    return 10.0 * math.log10((255.0 ** 2) / mse)
+
+
+def _encode_solids(path: Path, codec: str, device: str, pixel_format: str,
+                   cq: int) -> list[int]:
+    """Encode N_FRAMES solid frames with increasing value; return the values."""
+    values = [int(i * (200 / N_FRAMES)) + 16 for i in range(N_FRAMES)]
+    enc = VideoEncoder(str(path), codec=codec, width=WIDTH, height=HEIGHT,
+                       fps=FPS, pixel_format=pixel_format, cq=cq)
+    try:
+        for v in values:
+            enc.encode_frame(_solid_frame(v, device))
+    finally:
+        enc.close()
+    return values
+
+
+# --------------------------------------------------------------------------- #
+# Frame-count integrity
+# --------------------------------------------------------------------------- #
+def test_frame_count_cpu():
+    out = OUT_DIR / "count_cpu.mp4"
+    _encode_solids(out, "libx264", "cpu", "yuv420p", cq=23)
+    assert out.exists() and out.stat().st_size > 0
+    # Every submitted frame must become an encoded packet (no drops in the
+    # fan-out/reorder pipeline). Packet count is exact; decode-replay can differ
+    # by one due to the mp4 B-frame edit-list trim (see _decode_all).
+    assert _packet_count(out) == N_FRAMES
+    assert VideoReader(str(out)).total_frames == N_FRAMES
+
+
+@cuda_nvenc
+def test_frame_count_cuda():
+    out = OUT_DIR / "count_cuda.mp4"
+    _encode_solids(out, "h264_nvenc", "cuda", "nv12", cq=23)
+    assert out.exists() and out.stat().st_size > 0
+    assert _packet_count(out) == N_FRAMES
+    assert VideoReader(str(out)).total_frames == N_FRAMES
+
+
+# --------------------------------------------------------------------------- #
+# Frame-order integrity (the reorder map must preserve submission order)
+# --------------------------------------------------------------------------- #
+def _assert_monotonic(values: list[int], decoded: list[torch.Tensor]):
+    assert len(decoded) == len(values)
+    means = [fr.float().mean().item() for fr in decoded]
+    # Each frame's mean should track its source value monotonically. Allow a
+    # small slop for codec/colourspace rounding; the key property is ordering.
+    for i in range(1, len(means)):
+        assert means[i] >= means[i - 1] - 2.0, (
+            f"order broken at {i}: means={[round(m, 1) for m in means]}"
+        )
+    assert means[-1] - means[0] > 100.0, "expected a wide luma sweep across frames"
+
+
+def test_frame_order_cpu():
+    out = OUT_DIR / "order_cpu.mp4"
+    values = _encode_solids(out, "libx264", "cpu", "yuv444p", cq=0)
+    _assert_monotonic(values, _decode_all(out))
+
+
+@cuda_nvenc
+def test_frame_order_cuda():
+    out = OUT_DIR / "order_cuda.mp4"
+    values = _encode_solids(out, "h264_nvenc", "cuda", "nv12", cq=18)
+    _assert_monotonic(values, _decode_all(out))
+
+
+# --------------------------------------------------------------------------- #
+# PSNR floor (convert + encode round-trip fidelity)
+# --------------------------------------------------------------------------- #
+def test_psnr_floor_cpu():
+    out = OUT_DIR / "psnr_cpu.mp4"
+    src = _gradient_frame("cpu")
+    enc = VideoEncoder(str(out), codec="libx264", width=WIDTH, height=HEIGHT,
+                       fps=FPS, pixel_format="yuv444p", cq=0)
+    try:
+        for _ in range(N_FRAMES):
+            enc.encode_frame(src)
+    finally:
+        enc.close()
+    decoded = _decode_all(out)
+    assert len(decoded) == N_FRAMES
+    psnr = _psnr(src.cpu(), decoded[-1])
+    assert psnr >= 40.0, f"CPU round-trip PSNR too low: {psnr:.2f} dB"
+
+
+@cuda_nvenc
+def test_psnr_floor_cuda():
+    out = OUT_DIR / "psnr_cuda.mp4"
+    src = _gradient_frame("cuda")
+    enc = VideoEncoder(str(out), codec="h264_nvenc", width=WIDTH, height=HEIGHT,
+                       fps=FPS, pixel_format="nv12", cq=10)
+    try:
+        for _ in range(N_FRAMES):
+            enc.encode_frame(src)
+    finally:
+        enc.close()
+    decoded = _decode_all(out)
+    assert len(decoded) == N_FRAMES
+    # NVENC + NV12 (4:2:0) is lossy; floor is lower than the CPU yuv444 path.
+    psnr = _psnr(src.cpu(), decoded[-1])
+    assert psnr >= 30.0, f"NVENC round-trip PSNR too low: {psnr:.2f} dB"
+
+
+# --------------------------------------------------------------------------- #
+# Error propagation
+# --------------------------------------------------------------------------- #
+def test_wrong_size_tensor_raises():
+    """A tensor whose element count != width*height*3 is rejected up front."""
+    out = OUT_DIR / "err_size.mp4"
+    enc = VideoEncoder(str(out), codec="libx264", width=WIDTH, height=HEIGHT,
+                       fps=FPS, pixel_format="yuv420p")
+    try:
+        with pytest.raises((ValueError, RuntimeError)):
+            enc.encode_frame(torch.zeros((HEIGHT // 2, WIDTH, 3), dtype=torch.uint8))
+    finally:
+        enc.close()  # must not deadlock or crash after a rejected frame
+
+
+def test_midstream_error_clean_teardown():
+    """
+    A bad frame mid-stream raises, but the good frames already submitted still
+    reach the container and close() completes without deadlock. Exercises the
+    recycle-on-error + drain/join path of the async pipeline.
+    """
+    out = OUT_DIR / "err_midstream.mp4"
+    good = N_FRAMES // 2
+    enc = VideoEncoder(str(out), codec="libx264", width=WIDTH, height=HEIGHT,
+                       fps=FPS, pixel_format="yuv420p", cq=23)
+    try:
+        for i in range(good):
+            enc.encode_frame(_solid_frame(20 + i, "cpu"))
+        with pytest.raises((ValueError, RuntimeError)):
+            enc.encode_frame(torch.zeros((1, 1, 3), dtype=torch.uint8))  # bad size
+        # Pipeline must stay usable: keep encoding good frames after the reject.
+        for i in range(good):
+            enc.encode_frame(_solid_frame(120 + i, "cpu"))
+    finally:
+        enc.close()
+
+    assert out.exists() and out.stat().st_size > 0
+    # The rejected frame never entered the pipeline, so exactly 2*good land.
+    assert VideoReader(str(out)).total_frames == 2 * good
+
+
+# --------------------------------------------------------------------------- #
+# nvdec -> nvenc smoke (realistic decode -> encode wiring)
+# --------------------------------------------------------------------------- #
+@cuda_nvenc
+def test_nvdec_to_nvenc_smoke():
+    src = OUT_DIR / "smoke_src.mp4"
+    _encode_solids(src, "libx264", "cpu", "yuv420p", cq=20)
+
+    reader = VideoReader(str(src), decode_accelerator="nvdec", cuda_device_index=0)
+    dst = OUT_DIR / "smoke_nvenc.mp4"
+    enc = VideoEncoder(str(dst), codec="h264_nvenc",
+                       width=reader.width, height=reader.height, fps=float(reader.fps))
+    n = 0
+    try:
+        for frame in reader:
+            enc.encode_frame(frame)
+            n += 1
+    finally:
+        enc.close()
+
+    assert n == N_FRAMES
+    assert dst.exists() and dst.stat().st_size > 0
+    assert VideoReader(str(dst)).total_frames == N_FRAMES
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_async_encode_pipeline.py
+++ b/tests/test_async_encode_pipeline.py
@@ -150,8 +150,12 @@ def test_frame_count_cuda():
 # --------------------------------------------------------------------------- #
 # Frame-order integrity (the reorder map must preserve submission order)
 # --------------------------------------------------------------------------- #
-def _assert_monotonic(values: list[int], decoded: list[torch.Tensor]):
-    assert len(decoded) == len(values)
+def _assert_monotonic(values: list[int], decoded: list):
+    # A decoder may replay one fewer frame than encoded (mp4 B-frame edit-list
+    # trim); ordering is the property under test, not the exact count.
+    assert len(values) - 1 <= len(decoded) <= len(values), (
+        f"decoded {len(decoded)} frames, expected ~{len(values)}"
+    )
     means = [fr.float().mean().item() for fr in decoded]
     # Each frame's mean should track its source value monotonically. Allow a
     # small slop for codec/colourspace rounding; the key property is ordering.
@@ -189,7 +193,7 @@ def test_psnr_floor_cpu():
     finally:
         enc.close()
     decoded = _decode_all(out)
-    assert len(decoded) == N_FRAMES
+    assert len(decoded) >= N_FRAMES - 1  # mp4 B-frame edit-list may trim one
     psnr = _psnr(src.cpu(), decoded[-1])
     assert psnr >= 40.0, f"CPU round-trip PSNR too low: {psnr:.2f} dB"
 
@@ -206,7 +210,7 @@ def test_psnr_floor_cuda():
     finally:
         enc.close()
     decoded = _decode_all(out)
-    assert len(decoded) == N_FRAMES
+    assert len(decoded) >= N_FRAMES - 1  # mp4 B-frame edit-list may trim one
     # NVENC + NV12 (4:2:0) is lossy; floor is lower than the CPU yuv444 path.
     psnr = _psnr(src.cpu(), decoded[-1])
     assert psnr >= 30.0, f"NVENC round-trip PSNR too low: {psnr:.2f} dB"

--- a/tests/test_passthrough.py
+++ b/tests/test_passthrough.py
@@ -11,7 +11,7 @@ Usage:
   python tests/test_passthrough.py --src tests/data/BigBuckBunny.mp4
 """
 from __future__ import annotations
-import argparse, json, os, subprocess, sys, tempfile
+import argparse, json, os, shutil, subprocess, sys, tempfile
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
@@ -19,7 +19,15 @@ sys.path.insert(0, str(HERE.parent))
 FFBIN = HERE.parent / "external" / "ffmpeg" / "bin"
 if FFBIN.exists() and hasattr(os, "add_dll_directory"):
     os.add_dll_directory(str(FFBIN))
-FFPROBE = str(FFBIN / "ffprobe.exe")
+
+
+def _find_ffprobe() -> str:
+    exe = "ffprobe.exe" if os.name == "nt" else "ffprobe"
+    bundled = FFBIN / exe
+    return str(bundled) if bundled.exists() else (shutil.which("ffprobe") or exe)
+
+
+FFPROBE = _find_ffprobe()
 
 
 def probe(path: Path) -> list[dict]:

--- a/tests/test_passthrough.py
+++ b/tests/test_passthrough.py
@@ -1,0 +1,170 @@
+"""Manual test for VideoEncoder.add_passthrough (audio/sub copy + -ss/-to trim).
+
+Decodes frames with nelux, encodes a trimmed window, copies audio from the
+source, then ffprobes the output to confirm:
+  - an audio stream exists and is a stream-copy (same codec as source),
+  - video + audio durations match the requested window,
+  - non-zero start rebases audio to ~t=0 (no leading silence/offset),
+  - calling add_passthrough after the first frame raises.
+
+Usage:
+  python tests/test_passthrough.py --src tests/data/BigBuckBunny.mp4
+"""
+from __future__ import annotations
+import argparse, json, os, subprocess, sys, tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent))
+FFBIN = HERE.parent / "external" / "ffmpeg" / "bin"
+if FFBIN.exists() and hasattr(os, "add_dll_directory"):
+    os.add_dll_directory(str(FFBIN))
+FFPROBE = str(FFBIN / "ffprobe.exe")
+
+
+def probe(path: Path) -> list[dict]:
+    cmd = [FFPROBE, "-v", "error", "-show_streams", "-of", "json", str(path)]
+    out = subprocess.run(cmd, capture_output=True, text=True, check=True).stdout
+    return json.loads(out)["streams"]
+
+
+def stream_dur(st: dict) -> float:
+    # duration may live on the stream or only in tags (mkv/mp4 variance).
+    d = st.get("duration")
+    if d is None:
+        d = st.get("tags", {}).get("DURATION") or st.get("tags", {}).get("duration")
+    try:
+        return float(d)
+    except (TypeError, ValueError):
+        return -1.0
+
+
+def run_case(src: str, out: Path, start: float, end: float, *, want_subs: bool):
+    import torch  # must precede nelux
+    import nelux
+
+    r = nelux.VideoReader(src, backend="pytorch", decode_accelerator="cpu")
+    w, h, fps = r.width, r.height, float(r.fps)
+    nframes = int(round((end - start) * fps))
+
+    enc = nelux.VideoEncoder(str(out), codec="libx264", width=w, height=h,
+                             fps=fps, pixel_format="yuv420p", preset="veryfast",
+                             cq=18)
+    enc.add_passthrough(src, audio=True, subtitles=want_subs, start=start, end=end)
+
+    # We push only the frames belonging to [start, end). Skip to the start
+    # frame first, then encode nframes.
+    skip = int(round(start * fps))
+    for _ in range(skip):
+        r.read_frame()
+    pushed = 0
+    for _ in range(nframes):
+        try:
+            t = r.read_frame()
+        except (StopIteration, RuntimeError):
+            break
+        if t is None:
+            break
+        enc.encode_frame(t.contiguous())
+        pushed += 1
+    enc.close()
+    del r
+    return w, h, fps, pushed
+
+
+def check(out: Path, start: float, end: float, src: str):
+    window = end - start
+    streams = probe(out)
+    types = {}
+    for st in streams:
+        types.setdefault(st["codec_type"], []).append(st)
+    print(f"  output streams: "
+          + ", ".join(f"{k}={v[0]['codec_name']}" for k, v in types.items()))
+
+    ok = True
+    if "video" not in types:
+        print("  FAIL: no video stream"); ok = False
+    else:
+        vd = stream_dur(types["video"][0])
+        print(f"  video duration: {vd:.3f}s (want ~{window:.3f}s)")
+        if abs(vd - window) > 0.5:
+            print("  WARN: video duration off by >0.5s");
+
+    if "audio" not in types:
+        print("  FAIL: audio stream missing (passthrough did not copy it)"); ok = False
+    else:
+        src_audio = next((s for s in probe(Path(src)) if s["codec_type"] == "audio"), None)
+        ac = types["audio"][0]["codec_name"]
+        ad = stream_dur(types["audio"][0])
+        print(f"  audio codec: {ac} (source: {src_audio['codec_name'] if src_audio else '?'})")
+        print(f"  audio duration: {ad:.3f}s (want ~{window:.3f}s)")
+        if src_audio and ac != src_audio["codec_name"]:
+            print("  FAIL: audio codec changed -> not a stream copy"); ok = False
+        if ad >= 0 and abs(ad - window) > 0.7:
+            print("  WARN: audio duration off by >0.7s (packet-granular trim)")
+        # First audio packet should be near 0 after rebasing.
+        first_pts = subprocess.run(
+            [FFPROBE, "-v", "error", "-select_streams", "a:0", "-show_entries",
+             "packet=pts_time", "-of", "csv=p=0", "-read_intervals", "%+#1", str(out)],
+            capture_output=True, text=True).stdout.strip().splitlines()
+        if first_pts:
+            fp = float(first_pts[0].split(",")[0] or 0)
+            print(f"  first audio pts: {fp:.3f}s (want ~0 after rebasing)")
+            if fp > 0.5:
+                print("  WARN: audio not rebased to ~0")
+    return ok
+
+
+def test_guard(src: str, out: Path):
+    """add_passthrough after the first frame must raise."""
+    import torch
+    import nelux
+    r = nelux.VideoReader(src, backend="pytorch", decode_accelerator="cpu")
+    enc = nelux.VideoEncoder(str(out), codec="libx264", width=r.width,
+                             height=r.height, fps=float(r.fps),
+                             pixel_format="yuv420p", preset="ultrafast")
+    enc.encode_frame(r.read_frame().contiguous())
+    raised = False
+    try:
+        enc.add_passthrough(src, audio=True)
+    except Exception as e:  # noqa: BLE001
+        raised = True
+        print(f"  guard raised as expected: {type(e).__name__}: {e}")
+    enc.close()
+    del r
+    print("  PASS" if raised else "  FAIL: guard did not raise")
+    return raised
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--src", default=str(HERE / "data" / "BigBuckBunny.mp4"))
+    args = ap.parse_args()
+    wd = Path(tempfile.mkdtemp(prefix="nelux_pt_"))
+    print(f"workdir: {wd}\nsrc: {args.src}\n")
+
+    allok = True
+
+    print("[case 1] start=0 end=4 (audio copy, no trim offset)")
+    o1 = wd / "c1.mp4"
+    run_case(args.src, o1, 0.0, 4.0, want_subs=False)
+    allok &= check(o1, 0.0, 4.0, args.src)
+    print()
+
+    print("[case 2] start=2 end=6 (audio copy + rebase to 0)")
+    o2 = wd / "c2.mp4"
+    run_case(args.src, o2, 2.0, 6.0, want_subs=False)
+    allok &= check(o2, 2.0, 6.0, args.src)
+    print()
+
+    print("[case 3] guard: add_passthrough after encode_frame must raise")
+    allok &= test_guard(args.src, wd / "c3.mp4")
+    print()
+
+    print("ALL PASS" if allok else "SOME CHECKS FAILED")
+    print(f"outputs in {wd}")
+    sys.exit(0 if allok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_passthrough.py
+++ b/tests/test_passthrough.py
@@ -115,8 +115,13 @@ def check(out: Path, start: float, end: float, src: str):
     return ok
 
 
-def test_guard(src: str, out: Path):
-    """add_passthrough after the first frame must raise."""
+def guard_case(src: str, out: Path):
+    """add_passthrough after the first frame must raise.
+
+    Named without a ``test_`` prefix so pytest does not collect it as a test
+    (it takes positional args, not fixtures); this module is a manual CLI
+    script run via ``python tests/test_passthrough.py``.
+    """
     import torch
     import nelux
     r = nelux.VideoReader(src, backend="pytorch", decode_accelerator="cpu")
@@ -158,7 +163,7 @@ def main():
     print()
 
     print("[case 3] guard: add_passthrough after encode_frame must raise")
-    allok &= test_guard(args.src, wd / "c3.mp4")
+    allok &= guard_case(args.src, wd / "c3.mp4")
     print()
 
     print("ALL PASS" if allok else "SOME CHECKS FAILED")

--- a/tests/test_transcode.py
+++ b/tests/test_transcode.py
@@ -13,7 +13,7 @@ Usage:
       --submkv <path-to-mkv-with-subrip>
 """
 from __future__ import annotations
-import argparse, json, os, subprocess, sys, tempfile
+import argparse, json, os, shutil, subprocess, sys, tempfile
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
@@ -21,7 +21,15 @@ sys.path.insert(0, str(HERE.parent))
 FFBIN = HERE.parent / "external" / "ffmpeg" / "bin"
 if FFBIN.exists() and hasattr(os, "add_dll_directory"):
     os.add_dll_directory(str(FFBIN))
-FFPROBE = str(FFBIN / "ffprobe.exe")
+
+
+def _find_ffprobe() -> str:
+    exe = "ffprobe.exe" if os.name == "nt" else "ffprobe"
+    bundled = FFBIN / exe
+    return str(bundled) if bundled.exists() else (shutil.which("ffprobe") or exe)
+
+
+FFPROBE = _find_ffprobe()
 
 
 def streams_by_type(path: Path) -> dict[str, list[dict]]:

--- a/tests/test_transcode.py
+++ b/tests/test_transcode.py
@@ -1,0 +1,108 @@
+"""Test add_passthrough transcode fallback (allow_transcode).
+
+Forces container/codec mismatches so streams must be re-encoded:
+  - aac audio -> .webm  => transcoded to opus/vorbis (aac not allowed in webm)
+  - same, allow_transcode=False => audio dropped
+  - subrip subs -> .mp4 => transcoded to mov_text (subrip not allowed in mp4)
+
+Needs a subrip-bearing mkv built by the caller (pass --submkv) for the
+subtitle case; audio cases use BigBuckBunny.
+
+Usage:
+  python tests/test_transcode.py --src tests/data/BigBuckBunny.mp4 \
+      --submkv <path-to-mkv-with-subrip>
+"""
+from __future__ import annotations
+import argparse, json, os, subprocess, sys, tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent))
+FFBIN = HERE.parent / "external" / "ffmpeg" / "bin"
+if FFBIN.exists() and hasattr(os, "add_dll_directory"):
+    os.add_dll_directory(str(FFBIN))
+FFPROBE = str(FFBIN / "ffprobe.exe")
+
+
+def streams_by_type(path: Path) -> dict[str, list[dict]]:
+    cmd = [FFPROBE, "-v", "error", "-show_streams", "-of", "json", str(path)]
+    out = subprocess.run(cmd, capture_output=True, text=True, check=True).stdout
+    d: dict[str, list[dict]] = {}
+    for st in json.loads(out)["streams"]:
+        d.setdefault(st["codec_type"], []).append(st)
+    return d
+
+
+def encode(src: str, out: Path, vcodec: str, *, audio: bool, subs: bool,
+           end: float, allow_transcode: bool):
+    import torch  # noqa: F401  (must precede nelux)
+    import nelux
+    r = nelux.VideoReader(src, backend="pytorch", decode_accelerator="cpu")
+    w, h, fps = r.width, r.height, float(r.fps)
+    n = int(round(end * fps))
+    enc = nelux.VideoEncoder(str(out), codec=vcodec, width=w, height=h, fps=fps,
+                             pixel_format="yuv420p", preset="ultrafast" if "x26" in vcodec else None)
+    enc.add_passthrough(src, audio=audio, subtitles=subs, start=0.0, end=end,
+                        allow_transcode=allow_transcode)
+    for _ in range(n):
+        t = r.read_frame()
+        if t is None:
+            break
+        enc.encode_frame(t.contiguous())
+    enc.close()
+    del r
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--src", default=str(HERE / "data" / "BigBuckBunny.mp4"))
+    ap.add_argument("--submkv", default="")
+    args = ap.parse_args()
+    wd = Path(tempfile.mkdtemp(prefix="nelux_tc_"))
+    print(f"workdir: {wd}\n")
+    allok = True
+
+    print("[case 1] aac -> webm, allow_transcode=True (expect re-encode, not aac)")
+    o1 = wd / "c1.webm"
+    encode(args.src, o1, "libsvtav1", audio=True, subs=False, end=4.0, allow_transcode=True)
+    s1 = streams_by_type(o1)
+    a1 = s1.get("audio", [{}])
+    ac = a1[0].get("codec_name") if a1 and a1[0] else None
+    print(f"  audio codec: {ac} (video: {s1.get('video',[{}])[0].get('codec_name')})")
+    ok1 = bool(a1) and ac not in (None, "aac")
+    print("  PASS" if ok1 else "  FAIL: expected transcoded audio (opus/vorbis)")
+    allok &= ok1
+    print()
+
+    print("[case 2] aac -> webm, allow_transcode=False (expect audio dropped)")
+    o2 = wd / "c2.webm"
+    encode(args.src, o2, "libsvtav1", audio=True, subs=False, end=4.0, allow_transcode=False)
+    s2 = streams_by_type(o2)
+    ok2 = "audio" not in s2
+    print(f"  audio present: {'audio' in s2} (want False)")
+    print("  PASS" if ok2 else "  FAIL: audio should have been dropped")
+    allok &= ok2
+    print()
+
+    if args.submkv and Path(args.submkv).exists():
+        print("[case 3] subrip -> mp4, allow_transcode=True (expect mov_text)")
+        o3 = wd / "c3.mp4"
+        encode(args.submkv, o3, "libx264", audio=True, subs=True, end=5.0, allow_transcode=True)
+        s3 = streams_by_type(o3)
+        sub = s3.get("subtitle", [{}])
+        sc = sub[0].get("codec_name") if sub and sub[0] else None
+        print(f"  subtitle codec: {sc} (audio: {s3.get('audio',[{}])[0].get('codec_name')})")
+        ok3 = bool(sub) and sc in ("mov_text", "tx3g")
+        print("  PASS" if ok3 else "  FAIL: expected mov_text subtitle")
+        allok &= ok3
+    else:
+        print("[case 3] skipped (no --submkv given)")
+    print()
+
+    print("ALL PASS" if allok else "SOME CHECKS FAILED")
+    print(f"outputs in {wd}")
+    sys.exit(0 if allok else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Reworks the encoder onto an async fan-out pipeline, adds passthrough trim/transcode, and hardens `encode_frame` input handling. Tests cover the new pipeline on CPU and CUDA paths.

## Changes
**Encoder pipeline**
- Fan-out convert pool (parallel swscale RGB→YUV) feeding a single in-order submit thread via a seq-keyed reorder map. GPU/NVENC jobs skip the convert pool and convert on the submit thread (zero-copy).
- Bounded in-flight backpressure + recycled staging/YUV pools; clean drain/join teardown that re-raises the first worker error at `close()`.

**Passthrough**
- `add_passthrough` gains `allow_transcode`: streams the output container can't stream-copy are re-encoded to the container default instead of being dropped.

**Robustness**
- Validate `encode_frame` input size (`numel == w*h*3`) while the GIL is held → `ValueError` instead of an out-of-bounds staging read.
- Remove the temporary `[encstat]` convert/encode timing instrumentation.

## Tests
`tests/test_async_encode_pipeline.py` — 9 tests, all passing locally:
- frame-count + order integrity (reorder map preserves submission order)
- PSNR floor (CPU yuv444 / NVENC nv12 round-trip)
- shape-guard raise + mid-stream-error clean teardown
- nvdec→nvenc smoke

CUDA/NVENC variants skip cleanly without hardware. `test_passthrough.py` / `test_transcode.py` are manual CLI scripts for the trim + transcode-fallback paths.

## Notes
- **Worker re-raise**: no deterministic public-API trigger exists (NVENC faults validate at construction; CPU convert/submit threads have no public fault path), so the re-raise machinery is covered indirectly via the mid-stream-teardown test.
- **Decode-side edit-list trim**: a libx264+B-frame mp4 replays 24→23 frames (ffmpeg behaves identically; encoder emits all 24 packets with correct PTS). Decoder-side, separate from this work; documented in the test docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)