### PR TITLE
fix: import nelux on CPU-only PyTorch (defer CUDA runtime)

### DIFF
--- a/.github/workflows/createRelease.yaml
+++ b/.github/workflows/createRelease.yaml
@@ -416,6 +416,31 @@ jobs:
           export FFMPEG_BIN="${GITHUB_WORKSPACE}/external/ffmpeg/bin"
           python tests/wheel_smoke_test.py
 
+      - name: Verify import on CPU-only torch (lite-profile regression guard)
+        run: |
+          set -euo pipefail
+          # Fresh env with CPU-only torch — the previously-broken "lite" profile.
+          # The wheel MUST import here: no eager libc10_cuda.so (resolved via
+          # dlsym) and no eager libcudart.so (static-linked). A failure means the
+          # CPU-torch import regression is back.
+          python -m venv /tmp/cpuenv
+          . /tmp/cpuenv/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install "torch==2.12.0" --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install dist/*.whl
+          export LD_LIBRARY_PATH="${GITHUB_WORKSPACE}/external/ffmpeg/lib:${LD_LIBRARY_PATH:-}"
+          export PATH="${GITHUB_WORKSPACE}/external/ffmpeg/bin:${PATH}"
+          export FFMPEG_BIN="${GITHUB_WORKSPACE}/external/ffmpeg/bin"
+          python -c "import torch; assert torch.version.cuda is None, torch.version.cuda; import nelux; print('import OK on CPU torch:', nelux.__version__)"
+          SO=$(python -c "import nelux,glob,os;print(glob.glob(os.path.join(os.path.dirname(nelux.__file__),'_nelux*.so'))[0])")
+          echo "== NEEDED of $SO =="; readelf -d "$SO" | grep NEEDED || true
+          if readelf -d "$SO" | grep -qE 'NEEDED.*(libc10_cuda|libcudart|libtorch_cuda)'; then
+            echo "FAIL: eager CUDA lib still in NEEDED (import would break on CPU-only torch)"; exit 1
+          fi
+          echo "OK: no eager CUDA libs in NEEDED"
+          python tests/wheel_smoke_test.py
+          deactivate
+
       - name: Upload Linux wheel
         uses: actions/upload-artifact@v4
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,21 +363,17 @@ if(NELUX_ENABLE_CUDA)
   
   if(NELUX_CUDA_CU_SOURCES)
     add_library(NeluxCuda STATIC ${NELUX_CUDA_CU_SOURCES})
-    # Static-link the CUDA runtime on Linux so libcudart.so is not an eager
-    # DT_NEEDED of _nelux.so: CPU-only torch ships no libcudart.so, and the GPU
-    # paths that use it are runtime-gated. Windows keeps its existing behaviour
-    # (the runtime is already resolved statically into the .pyd — no cudart in
-    # the import table).
-    if(WIN32)
-      set(_NELUX_CUDA_RT Shared)
-    else()
-      set(_NELUX_CUDA_RT Static)
-    endif()
+    # Static-link the CUDA runtime on every platform so cudart is not an eager
+    # dependency of _nelux (libcudart.so / cudart64_*.dll). CPU-only torch ships
+    # no CUDA runtime and the GPU paths that use it are runtime-gated, so the
+    # module must load without it. Windows was already de-facto static (no cudart
+    # in the import table); making it explicit closes the gap if a future
+    # toolchain default changes.
     set_target_properties(NeluxCuda PROPERTIES
       CUDA_SEPARABLE_COMPILATION OFF
       POSITION_INDEPENDENT_CODE ON
       CUDA_STANDARD 17
-      CUDA_RUNTIME_LIBRARY ${_NELUX_CUDA_RT}
+      CUDA_RUNTIME_LIBRARY Static
     )
     target_include_directories(NeluxCuda PUBLIC
       ${CMAKE_CURRENT_SOURCE_DIR}/include
@@ -419,11 +415,12 @@ if(NELUX_ENABLE_CUDA)
   if(TARGET NeluxCuda)
     target_link_libraries(NeluxLib PUBLIC NeluxCuda)
   endif()
-  # Linux: static cudart so _nelux.so does not list libcudart.so as NEEDED
-  # (absent on CPU-only torch). Covers cudart calls from CXX TUs such as the
-  # NVDEC Decoder; cudart_static pulls its own -ldl/-lrt/-lpthread via CMake.
-  # Pairs with NeluxCuda's CUDA_RUNTIME_LIBRARY=Static above.
-  if(UNIX AND NOT APPLE)
+  # Static cudart so _nelux does not list a CUDA runtime as an eager dependency
+  # (libcudart.so / cudart64_*.dll — absent on CPU-only torch). Covers cudart
+  # calls from CXX TUs such as the NVDEC Decoder; pairs with NeluxCuda's
+  # CUDA_RUNTIME_LIBRARY=Static. (cudart_static pulls -ldl/-lrt/-lpthread on
+  # Linux via CMake.)
+  if(TARGET CUDA::cudart_static)
     target_link_libraries(NeluxLib PUBLIC CUDA::cudart_static)
   endif()
 endif()
@@ -452,8 +449,13 @@ target_link_libraries(NeluxLib PUBLIC
   $<$<BOOL:${NELUX_BUILD_PYTHON}>:c10>
   $<$<BOOL:${NELUX_BUILD_PYTHON}>:torch>
   $<$<BOOL:${NELUX_BUILD_PYTHON}>:torch_python>
-  $<$<AND:$<BOOL:${NELUX_BUILD_PYTHON}>,$<BOOL:${NELUX_ENABLE_CUDA}>>:torch_cuda>
-  $<$<AND:$<BOOL:${NELUX_BUILD_PYTHON}>,$<BOOL:${NELUX_ENABLE_CUDA}>>:c10_cuda>
+  # Windows ONLY: c10_cuda/torch_cuda are delay-loaded (see /DELAYLOAD) so they
+  # stay out of the eager import table while the import lib is present for the
+  # delay-load thunk. On Linux a plain -lc10_cuda becomes a DT_NEEDED even when
+  # unused (no --as-needed), which would break import on CPU-only torch; there
+  # the symbol is resolved at runtime via dlsym (src/Nelux/CudaStream.cpp).
+  $<$<AND:$<BOOL:${NELUX_BUILD_PYTHON}>,$<BOOL:${NELUX_ENABLE_CUDA}>,$<PLATFORM_ID:Windows>>:torch_cuda>
+  $<$<AND:$<BOOL:${NELUX_BUILD_PYTHON}>,$<BOOL:${NELUX_ENABLE_CUDA}>,$<PLATFORM_ID:Windows>>:c10_cuda>
 )
 if(WIN32)
   target_link_libraries(NeluxLib PUBLIC ws2_32 bcrypt)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,11 +363,21 @@ if(NELUX_ENABLE_CUDA)
   
   if(NELUX_CUDA_CU_SOURCES)
     add_library(NeluxCuda STATIC ${NELUX_CUDA_CU_SOURCES})
+    # Static-link the CUDA runtime on Linux so libcudart.so is not an eager
+    # DT_NEEDED of _nelux.so: CPU-only torch ships no libcudart.so, and the GPU
+    # paths that use it are runtime-gated. Windows keeps its existing behaviour
+    # (the runtime is already resolved statically into the .pyd — no cudart in
+    # the import table).
+    if(WIN32)
+      set(_NELUX_CUDA_RT Shared)
+    else()
+      set(_NELUX_CUDA_RT Static)
+    endif()
     set_target_properties(NeluxCuda PROPERTIES
       CUDA_SEPARABLE_COMPILATION OFF
       POSITION_INDEPENDENT_CODE ON
       CUDA_STANDARD 17
-      CUDA_RUNTIME_LIBRARY Shared
+      CUDA_RUNTIME_LIBRARY ${_NELUX_CUDA_RT}
     )
     target_include_directories(NeluxCuda PUBLIC
       ${CMAKE_CURRENT_SOURCE_DIR}/include
@@ -408,6 +418,13 @@ if(NELUX_ENABLE_CUDA)
   target_compile_definitions(NeluxLib PUBLIC NELUX_ENABLE_CUDA)
   if(TARGET NeluxCuda)
     target_link_libraries(NeluxLib PUBLIC NeluxCuda)
+  endif()
+  # Linux: static cudart so _nelux.so does not list libcudart.so as NEEDED
+  # (absent on CPU-only torch). Covers cudart calls from CXX TUs such as the
+  # NVDEC Decoder; cudart_static pulls its own -ldl/-lrt/-lpthread via CMake.
+  # Pairs with NeluxCuda's CUDA_RUNTIME_LIBRARY=Static above.
+  if(UNIX AND NOT APPLE)
+    target_link_libraries(NeluxLib PUBLIC CUDA::cudart_static)
   endif()
 endif()
 
@@ -495,6 +512,24 @@ if(NELUX_BUILD_PYTHON)
         "/WHOLEARCHIVE:$<TARGET_FILE:NeluxCuda>"
       )
       message(STATUS "MSVC: Using /WHOLEARCHIVE for NeluxCuda to include all CUDA kernels in nelux")
+    endif()
+
+    if(WIN32 AND MSVC)
+      # Delay-load the CUDA PyTorch runtime so the module still IMPORTS on a
+      # CPU-only PyTorch (where c10_cuda.dll is absent). Every c10::cuda / CUDA
+      # code path is runtime-gated (frame.is_cuda(), NVDEC accelerator), so
+      # c10_cuda is only resolved when a GPU op actually runs. cudart is
+      # static-linked and the NVDEC driver DLLs are LoadLibrary'd at runtime, so
+      # neither appears in the import table. Without this, the eager c10_cuda
+      # import makes `import nelux` fail with WinError 126 on CPU-only torch.
+      # (torch_cuda.dll is listed defensively; if a build doesn't import it the
+      #  linker emits a benign LNK4199 and ignores the directive.)
+      # delayimp.lib is already linked above (FFmpeg delay-load block).
+      target_link_options(nelux PRIVATE
+        "/DELAYLOAD:c10_cuda.dll"
+        "/DELAYLOAD:torch_cuda.dll"
+      )
+      message(STATUS "MSVC: c10_cuda.dll/torch_cuda.dll delay-loaded — import works on CPU-only PyTorch")
     endif()
   endif()
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,11 @@
 
+### **Version 0.12.4 (2026-05-30)**
+
+#### **Fix: nelux imports on CPU-only PyTorch (Windows)**
+- **Fixed:** `import nelux` failed with `ImportError: DLL load failed while importing _nelux` (`WinError 126`) whenever the installed PyTorch was a CPU-only build. The CUDA-enabled wheel statically imported `c10_cuda.dll`, which ships only with CUDA PyTorch, so every nelux operation — including pure-CPU decode/encode — was unreachable on a CPU torch. CUDA is now **optional, never required to import**, on both Windows and Linux. The single torch-CUDA symbol nelux uses (`getCurrentCUDAStream`) is no longer linked eagerly: on **Windows** `c10_cuda.dll`/`torch_cuda.dll` are delay-loaded; on **Linux** the symbol is resolved via `dlsym` so `libc10_cuda.so` is not a `DT_NEEDED` dependency. The CUDA runtime is static-linked (Windows already did this; Linux now does too) so `libcudart.so` is not `NEEDED` either. The module therefore imports on any PyTorch and only touches the CUDA runtime when a GPU code path actually runs — NVENC/NVDEC are unchanged when CUDA PyTorch is present; requesting a GPU op without it now raises a clear error instead of a load-time crash. The post-install smoke test asserts import on a GPU-less runner, and the Linux release job additionally verifies import under CPU-only torch and asserts the built `.so` has no eager CUDA `NEEDED` entries — permanent regression guards. (macOS already builds CPU-only.)
+
+---
+
 ### **Version 0.12.3 (2026-05-30)**
 
 #### **Build: pin FFmpeg 8.x toolchain**

--- a/include/Nelux/CudaRuntimeGuard.hpp
+++ b/include/Nelux/CudaRuntimeGuard.hpp
@@ -1,0 +1,15 @@
+#pragma once
+// Guard for the delay-loaded CUDA PyTorch runtime (Windows).
+//
+// On Windows the CUDA torch DLL (c10_cuda.dll) is delay-loaded (see /DELAYLOAD
+// in CMakeLists.txt) so that `import nelux` works on a CPU-only PyTorch, where
+// that DLL is absent. Call requireCudaRuntime() at the entry of a GPU-only code
+// path (e.g. the NVDEC decoder) to fail with a clear message rather than a raw
+// delay-load crash when that runtime is missing. No-op off Windows / non-CUDA.
+namespace nelux {
+#if defined(NELUX_ENABLE_CUDA) && defined(_WIN32)
+void requireCudaRuntime();  // defined in src/Nelux/FFmpegDelayLoad.cpp
+#else
+inline void requireCudaRuntime() {}
+#endif
+}  // namespace nelux

--- a/include/Nelux/CudaStream.hpp
+++ b/include/Nelux/CudaStream.hpp
@@ -1,0 +1,18 @@
+#pragma once
+// torch's current CUDA stream, obtained WITHOUT an eager link against c10_cuda.
+//
+// c10_cuda (the PyTorch CUDA layer that exports getCurrentCUDAStream) ships only
+// with CUDA torch. Linking it eagerly makes the module fail to load on a
+// CPU-only PyTorch (WinError 126 / "cannot open shared object libc10_cuda.so").
+// We defer that dependency:
+//   - Windows: the symbol is delay-loaded (see /DELAYLOAD in CMakeLists.txt).
+//   - Linux:   resolved at runtime via dlsym (no DT_NEEDED on libc10_cuda.so).
+// Either way it is only touched on a real GPU code path, which cannot run on
+// CPU-only torch. Call this only on a confirmed-CUDA path; it throws if the
+// CUDA PyTorch runtime is unavailable.
+#ifdef NELUX_ENABLE_CUDA
+#include <cuda_runtime.h>
+namespace nelux {
+cudaStream_t currentCudaStream(int device);
+}  // namespace nelux
+#endif  // NELUX_ENABLE_CUDA

--- a/nelux/__init__.py
+++ b/nelux/__init__.py
@@ -226,7 +226,26 @@ from .batch import BatchMixin
 class VideoReader(BatchMixin, _VideoReaderBase):
     """VideoReader with batch frame reading support."""
 
-    pass
+    def __init__(self, *args, **kwargs):
+        # NVDEC needs a CUDA-capable, *active* PyTorch. The CUDA runtime is
+        # delay-loaded so the module imports on CPU-only torch; guard here so
+        # requesting nvdec on a CPU/GPU-less torch raises a clear error up front
+        # instead of failing deep in the decoder. torch.cuda.is_available() is
+        # safe on CPU torch (returns False without needing c10_cuda).
+        accel = kwargs.get("decode_accelerator")
+        if accel is None and len(args) >= 5:
+            accel = args[4]  # input_path, num_threads, force_8bit, backend, decode_accelerator
+        if isinstance(accel, str) and accel.lower() == "nvdec":
+            import torch
+
+            if not torch.cuda.is_available():
+                raise RuntimeError(
+                    "decode_accelerator='nvdec' requires a CUDA-enabled PyTorch "
+                    "with an available GPU, but torch.cuda.is_available() is False "
+                    "(CPU-only PyTorch or no NVIDIA GPU). Use "
+                    "decode_accelerator='cpu', or install a CUDA build of PyTorch."
+                )
+        super().__init__(*args, **kwargs)
 
 
 __all__ = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "nelux"
-version = "0.12.3"
+version = "0.12.4"
 readme = "README.md"
 authors = [
     {name = "Nilas Tiago", email = "nilascontact@gmail.com"},

--- a/src/Nelux/CudaStream.cpp
+++ b/src/Nelux/CudaStream.cpp
@@ -1,0 +1,61 @@
+#include <CudaStream.hpp>
+
+#ifdef NELUX_ENABLE_CUDA
+
+#include <c10/cuda/CUDAStream.h>  // c10::cuda::getCurrentCUDAStream, CUDAStream
+#include <stdexcept>
+
+#ifndef _WIN32
+#include <dlfcn.h>
+#endif
+
+namespace nelux {
+
+cudaStream_t currentCudaStream(int device)
+{
+    const auto idx = static_cast<c10::DeviceIndex>(device);
+#ifdef _WIN32
+    // c10_cuda.dll is delay-loaded (CMake /DELAYLOAD); the symbol resolves on
+    // first GPU op. Direct call is fine — it never runs on CPU-only torch.
+    return c10::cuda::getCurrentCUDAStream(idx).stream();
+#else
+    // Linux has no delay-load, and CPython dlopen's extensions with RTLD_NOW, so
+    // referencing the symbol directly would make libc10_cuda.so an eager
+    // DT_NEEDED and break `import nelux` on CPU-only torch. Resolve the two
+    // symbols we need at runtime instead. libc10_cuda.so is already loaded into
+    // the process (RTLD_GLOBAL) by CUDA torch before any GPU op can run.
+    //
+    // Mangled (Itanium) symbols, stable across torch versions:
+    //   c10::cuda::getCurrentCUDAStream(c10::DeviceIndex)  [DeviceIndex=int8_t]
+    //   c10::cuda::CUDAStream::stream() const
+    using GetStreamFn = c10::cuda::CUDAStream (*)(c10::DeviceIndex);
+    using ToCudaFn = cudaStream_t (*)(const c10::cuda::CUDAStream*);
+    static GetStreamFn getCurrent = nullptr;
+    static ToCudaFn toCuda = nullptr;
+    if (getCurrent == nullptr || toCuda == nullptr)
+    {
+        void* h = ::dlopen("libc10_cuda.so", RTLD_NOW | RTLD_GLOBAL | RTLD_NOLOAD);
+        if (h == nullptr)
+            h = ::dlopen("libc10_cuda.so", RTLD_NOW | RTLD_GLOBAL);
+        if (h != nullptr)
+        {
+            getCurrent = reinterpret_cast<GetStreamFn>(
+                ::dlsym(h, "_ZN3c104cuda20getCurrentCUDAStreamEa"));
+            toCuda = reinterpret_cast<ToCudaFn>(
+                ::dlsym(h, "_ZNK3c104cuda10CUDAStream6streamEv"));
+        }
+    }
+    if (getCurrent == nullptr || toCuda == nullptr)
+        throw std::runtime_error(
+            "GPU operation requires a CUDA build of PyTorch, but libc10_cuda.so "
+            "(or its getCurrentCUDAStream symbol) could not be resolved — your "
+            "PyTorch is CPU-only. Install a CUDA build of PyTorch for NVDEC/NVENC, "
+            "or use CPU decoding and software encoders.");
+    c10::cuda::CUDAStream s = getCurrent(idx);
+    return toCuda(&s);
+#endif
+}
+
+}  // namespace nelux
+
+#endif  // NELUX_ENABLE_CUDA

--- a/src/Nelux/FFmpegDelayLoad.cpp
+++ b/src/Nelux/FFmpegDelayLoad.cpp
@@ -8,6 +8,7 @@
 // Allow writable delay-load hook variables on MSVC
 #define DELAYIMP_INSECURE_WRITABLE_HOOKS
 #include <delayimp.h>
+#include <stdexcept>
 #include <string>
 
 // FFmpeg DLL versions to try in order of preference (newest first)
@@ -82,5 +83,27 @@ FARPROC WINAPI FFmpegDelayLoadHook(unsigned dliNotify, PDelayLoadInfo pdli) {
 
 ExternC PfnDliHook __pfnDliNotifyHook2 = FFmpegDelayLoadHook;
 ExternC PfnDliHook __pfnDliFailureHook2 = FFmpegDelayLoadHook;
+
+// ── CUDA runtime guard ──────────────────────────────────────────────────────
+// c10_cuda.dll is delay-loaded (see /DELAYLOAD in CMakeLists.txt) so the module
+// imports on a CPU-only PyTorch. If a GPU-only code path is reached without it
+// (e.g. NVDEC explicitly requested on a CPU-only torch), surface a clear error
+// here instead of a raw delay-load failure. Only touches KERNEL32, so it adds
+// no torch import of its own and cannot re-introduce the eager dependency.
+#ifdef NELUX_ENABLE_CUDA
+namespace nelux {
+void requireCudaRuntime()
+{
+    if (::GetModuleHandleA("c10_cuda.dll") != nullptr)
+        return;
+    if (::LoadLibraryA("c10_cuda.dll") != nullptr)
+        return;
+    throw std::runtime_error(
+        "GPU operation requires a CUDA build of PyTorch, but c10_cuda.dll is "
+        "missing (your PyTorch is CPU-only). Install a CUDA build of PyTorch to "
+        "use NVDEC/NVENC, or use CPU decoding and software encoders.");
+}
+}  // namespace nelux
+#endif  // NELUX_ENABLE_CUDA
 
 #endif // _WIN32

--- a/src/Nelux/backends/cuda/Decoder.cpp
+++ b/src/Nelux/backends/cuda/Decoder.cpp
@@ -7,6 +7,8 @@
 
 #include <c10/cuda/CUDAStream.h>
 
+#include <CudaRuntimeGuard.hpp>
+
 #include <BatchDecoder.hpp>
 #include <Logger.hpp>
 #include <chrono>
@@ -223,6 +225,10 @@ Decoder::Decoder(const std::string& filePath, int numThreads, int cudaDeviceInde
       mlOutputMode_(false), mlUseFP16_(false), mlMean_{0.0f, 0.0f, 0.0f},
       mlInvStd_{1.0f / 255.0f, 1.0f / 255.0f, 1.0f / 255.0f}
 {
+    // c10_cuda.dll is delay-loaded on Windows so the module imports on a
+    // CPU-only PyTorch; fail clearly here if NVDEC is reached without it.
+    nelux::requireCudaRuntime();
+
     // Async fanout uses CPU libswscale convert workers; CUDA decoder produces
     // AV_PIX_FMT_CUDA frames that cannot be fed to libswscale on the host. Disable.
     asyncFanoutEnabled_ = false;

--- a/src/Nelux/python/Bindings.cpp
+++ b/src/Nelux/python/Bindings.cpp
@@ -30,7 +30,7 @@ Backend backendFromString(const std::string& backend_str)
 PYBIND11_MODULE(_nelux, m)
 {
     m.doc() = "nelux – lightspeed video decoding into tensors";
-    m.attr("__version__") = "0.12.2";
+    m.attr("__version__") = "0.12.4";
 
     // Expose CUDA build status
 #ifdef NELUX_ENABLE_CUDA

--- a/src/Nelux/python/VideoEncoder.cpp
+++ b/src/Nelux/python/VideoEncoder.cpp
@@ -7,7 +7,7 @@
 #include <cpu/RGBToAuto.hpp>
 
 #ifdef NELUX_ENABLE_CUDA
-#include <c10/cuda/CUDAStream.h>  // c10::cuda::getCurrentCUDAStream
+#include <CudaStream.hpp>  // nelux::currentCudaStream (no eager c10_cuda link)
 #endif
 
 extern "C"
@@ -222,8 +222,7 @@ void VideoEncoder::encodeFrame(torch::Tensor frame)
             readyEvent = nullptr;
         if (readyEvent)
         {
-            cudaStream_t producerStream =
-                c10::cuda::getCurrentCUDAStream(deviceIndex).stream();
+            cudaStream_t producerStream = nelux::currentCudaStream(deviceIndex);
             cudaEventRecord(readyEvent, producerStream);
         }
 
@@ -336,7 +335,7 @@ void VideoEncoder::encodeFrame(torch::Tensor frame)
 #ifdef NELUX_ENABLE_CUDA
         int dev = frame.device().index();
         if (dev < 0) dev = 0;
-        cudaStream_t s = c10::cuda::getCurrentCUDAStream(dev).stream();
+        cudaStream_t s = nelux::currentCudaStream(dev);
         cudaError_t cerr = cudaMemcpyAsync(staging->data(), frame.data_ptr<uint8_t>(),
                                            rgbBytes, cudaMemcpyDeviceToHost, s);
         if (cerr == cudaSuccess)

--- a/tests/wheel_smoke_test.py
+++ b/tests/wheel_smoke_test.py
@@ -79,35 +79,13 @@ def main() -> int:
     # torch must be imported before nelux (enforced inside nelux).
     import torch  # noqa: F401
 
-    # A CUDA-enabled extension links the CUDA runtime; on Windows the c10_cuda
-    # DLL's init routine fails to load on a runner with no NVIDIA GPU (Linux's
-    # .so tolerates it). GitHub CI runners have no GPU, so a CUDA-init import
-    # failure there is expected, not a wheel defect — skip rather than fail.
-    # The build + dependency-bundling steps already ran; CUDA paths simply can't
-    # be exercised without a device. On a real GPU machine the import succeeds
-    # and the full decode test below runs.
-    try:
-        import nelux
-    except ImportError as exc:
-        msg = str(exc)
-        cuda_init_failure = any(
-            s in msg
-            for s in ("c10_cuda", "cudart", "initialization routine failed",
-                      "DLL load failed")
-        )
-        if cuda_init_failure and not torch.cuda.is_available():
-            print(f"[smoke] SKIP: CUDA-enabled extension cannot initialize on a "
-                  f"GPU-less runner (no NVIDIA device). Import error: {msg}",
-                  flush=True)
-            print("[smoke] Build + DLL bundling succeeded; CUDA-path validation "
-                  "requires a GPU and is skipped on CI.", flush=True)
-            # Hard-exit 0: after the failed CUDA DLL load the interpreter's
-            # normal shutdown returns a non-zero code, so os._exit bypasses
-            # finalizers to guarantee a clean success exit.
-            sys.stdout.flush()
-            sys.stderr.flush()
-            os._exit(0)
-        raise
+    # nelux must import on ANY PyTorch — CPU-only or CUDA, GPU present or not.
+    # The CUDA runtime (c10_cuda.dll / torch_cuda.dll) is delay-loaded on
+    # Windows, so a missing or uninitializable CUDA library must NOT block
+    # import; it only surfaces if a GPU op is actually requested. GitHub CI
+    # runners have no GPU, yet this import must still succeed — a failure here
+    # is a real regression of that contract, so do not skip it.
+    import nelux
 
     print(
         f"[smoke] nelux={nelux.__version__} "


### PR DESCRIPTION
## Problem
nelux 0.12.x links `c10_cuda` eagerly, so `import nelux` fails with `WinError 126` (Windows) / missing `libc10_cuda.so` (Linux) whenever the installed PyTorch is **CPU-only**. That breaks *every* operation — including pure-CPU decode/encode — because the C extension can't load. `c10_cuda` ships only with CUDA PyTorch, so the CUDA wheel structurally required a CUDA torch.

## Fix — defer the CUDA runtime (CUDA optional, never required to import)
The only torch-CUDA symbol nelux uses is `getCurrentCUDAStream` (2 sites in `VideoEncoder.cpp`). It's now centralized behind `nelux::currentCudaStream()` and resolved late:

- **Windows:** `/DELAYLOAD:c10_cuda.dll` + `torch_cuda.dll` — moved out of the eager import table.
- **Linux:** `dlsym` the symbol (+ `CUDAStream::stream()`) so `libc10_cuda.so` is not a `DT_NEEDED`; **static-link cudart** so `libcudart.so` isn't `NEEDED` either. (CPython dlopens extensions `RTLD_NOW`, so leaving symbols undefined isn't an option.)
- `VideoReader` guards `nvdec` with `torch.cuda.is_available()` → clean error instead of a load-time crash.
- `cudart` is static on both platforms; NVDEC driver DLLs are loaded at runtime. Neither blocks import.

GPU paths are unchanged when CUDA PyTorch is present (runtime-gated by `frame.is_cuda()` / nvdec).

## Verification
- `wheel_smoke_test.py` now **asserts** `import nelux` on a GPU-less runner (was skipped) — permanent regression guard.
- Linux release job: fresh **CPU-only torch** venv → asserts import + smoke, and `readelf -d` asserts no `libc10_cuda`/`libcudart`/`libtorch_cuda` in `NEEDED`.
- Verified locally on Windows (this is a CUDA dev box):
  - `.venv_cpu` (torch 2.12.0**+cpu**, no c10_cuda): import + CPU decode ✅
  - `.venv_cuda` (torch 2.12.0**+cu132**): import + CPU + NVDEC (`cuda:0`) + **NVENC roundtrip** ✅
  - PE import table: `c10_cuda` moved EAGER → DELAY; zero GPU eager deps.
- ⚠️ Linux GPU path (dlsym + static cudart) is exercised only by a CUDA-Linux run — CI's Linux runner is GPU-less. The CPU-import contract IS covered by CI.

`__version__` synced to 0.12.4 (was stale at 0.12.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)