### PR TITLE
feat(decoder): support rawvideo on NVDEC path

### DIFF
--- a/include/Nelux/backends/cuda/Decoder.hpp
+++ b/include/Nelux/backends/cuda/Decoder.hpp
@@ -15,6 +15,7 @@ extern "C" {
 #include <libavutil/hwcontext.h>
 #include <libavutil/hwcontext_cuda.h>
 #include <libavutil/pixdesc.h>
+#include <libswscale/swscale.h>
 }
 
 namespace nelux::backends::cuda
@@ -178,14 +179,20 @@ protected:
     void initialize(const std::string& filePath);
     void initHardwareContext();
     void initCodecContextWithHwAccel();
-    
+
+    // rawvideo passthrough: opens the FFmpeg software rawvideo decoder (no
+    // cuvid codec exists). Called from initCodecContextWithHwAccel.
+    void initRawPassthrough();
+
     /**
      * @brief Transfer and convert frame from NV12 to RGB on GPU
      * @param hwFrame Hardware frame from NVDEC
      * @param outputBuffer Output RGB buffer (device pointer)
      */
     void transferAndConvertFrame(AVFrame* hwFrame, void* outputBuffer, int outputPitch = 0);
-    
+    void transferAndConvertRawFrame(AVFrame* swFrame, void* outputBuffer,
+                                    int outputPitch = 0);
+
     // Static callback for FFmpeg hardware pixel format selection
     static AVPixelFormat getHwFormat(AVCodecContext* ctx, const AVPixelFormat* pix_fmts);
 
@@ -219,6 +226,18 @@ private:
 
     // Serialize access to shared CUDA buffers/stream across threads.
     std::mutex cudaDecodeMutex_;
+
+    // --- rawvideo passthrough (NVDEC path for uncompressed input) ---
+    // cuvid has no rawvideo codec, so when the demuxer reports
+    // AV_CODEC_ID_RAWVIDEO we open the FFmpeg software rawvideo decoder for
+    // parsing/framing. The consumer converts software frames to RGB24 and
+    // uploads them directly into the CUDA output path.
+    bool rawPassthroughMode_ = false;
+    // Cached software conversion state used before the device upload.
+    SwsContext* rawSwsCtx_ = nullptr;
+    // Pre-allocated scratch frame that rawSwsCtx_ writes into. Reused across
+    // frames; only one producer thread, so no extra sync needed.
+    AVFrame* rawSwsFrame_ = nullptr;
 };
 
 } // namespace nelux::backends::cuda

--- a/src/Nelux/backends/cuda/Decoder.cpp
+++ b/src/Nelux/backends/cuda/Decoder.cpp
@@ -432,6 +432,16 @@ void Decoder::initCodecContextWithHwAccel()
 {
     NELUX_DEBUG("CUDA DECODER: Initializing codec context with hardware acceleration");
 
+    // Reconfigure can switch between rawvideo and cuvid-backed codecs.
+    if (rawSwsFrame_)
+        av_frame_free(&rawSwsFrame_);
+    if (rawSwsCtx_)
+    {
+        sws_freeContext(rawSwsCtx_);
+        rawSwsCtx_ = nullptr;
+    }
+    rawPassthroughMode_ = false;
+
     AVCodecID codec_id = formatCtx->streams[videoStreamIndex]->codecpar->codec_id;
 
     // Find decoder that supports hardware acceleration
@@ -567,20 +577,10 @@ void Decoder::initRawPassthrough()
 {
     NELUX_INFO("CUDA DECODER: rawvideo passthrough requested (no cuvid codec)");
 
-    // Clean up any existing raw-passthrough state (supports reconfigure()).
-    if (rawSwsFrame_)
-        av_frame_free(&rawSwsFrame_);
-    if (rawSwsCtx_)
-    {
-        sws_freeContext(rawSwsCtx_);
-        rawSwsCtx_ = nullptr;
-    }
-    rawPassthroughMode_ = false;
-
     AVCodecParameters* par = formatCtx->streams[videoStreamIndex]->codecpar;
-    rawPassthroughMode_ = true;
     NELUX_INFO("CUDA DECODER: rawvideo src_fmt={}",
                av_get_pix_fmt_name(static_cast<AVPixelFormat>(par->format)));
+
     // Open the FFmpeg software rawvideo decoder. It is a near-no-op decoder
     // (no entropy coding to undo) that just wraps the raw bytes into AVFrames
     // honoring width/height/format from the container.
@@ -613,6 +613,8 @@ void Decoder::initRawPassthrough()
         av_strerror(ret, errbuf, sizeof(errbuf));
         throw CxException(std::string("Failed to open rawvideo codec: ") + errbuf);
     }
+
+    rawPassthroughMode_ = true;
 
     // No hwframe pool needed: the consumer thread (decodeNextFrame /
     // decodeNextFrameML) converts to RGB24 and uploads it directly. This avoids

--- a/src/Nelux/backends/cuda/Decoder.cpp
+++ b/src/Nelux/backends/cuda/Decoder.cpp
@@ -298,7 +298,9 @@ Decoder::Decoder(Decoder&& other) noexcept
       hwDeviceCtx_(other.hwDeviceCtx_), hwPixFmt_(other.hwPixFmt_),
       nv12Buffer_(other.nv12Buffer_), nv12BufferSize_(other.nv12BufferSize_),
       rgb24Buffer_(other.rgb24Buffer_), rgb24BufferSize_(other.rgb24BufferSize_),
-      hwInitialized_(other.hwInitialized_)
+      hwInitialized_(other.hwInitialized_),
+      rawPassthroughMode_(other.rawPassthroughMode_),
+      rawSwsCtx_(other.rawSwsCtx_), rawSwsFrame_(other.rawSwsFrame_)
 {
     other.cudaStream_ = nullptr;
     other.decodeCompleteEvent_ = nullptr;
@@ -307,6 +309,9 @@ Decoder::Decoder(Decoder&& other) noexcept
     other.nv12Buffer_ = nullptr;
     other.rgb24Buffer_ = nullptr;
     other.hwInitialized_ = false;
+    other.rawPassthroughMode_ = false;
+    other.rawSwsCtx_ = nullptr;
+    other.rawSwsFrame_ = nullptr;
 }
 
 Decoder& Decoder::operator=(Decoder&& other) noexcept
@@ -328,6 +333,9 @@ Decoder& Decoder::operator=(Decoder&& other) noexcept
         rgb24Buffer_ = other.rgb24Buffer_;
         rgb24BufferSize_ = other.rgb24BufferSize_;
         hwInitialized_ = other.hwInitialized_;
+        rawPassthroughMode_ = other.rawPassthroughMode_;
+        rawSwsCtx_ = other.rawSwsCtx_;
+        rawSwsFrame_ = other.rawSwsFrame_;
 
         other.cudaStream_ = nullptr;
         other.decodeCompleteEvent_ = nullptr;
@@ -336,6 +344,9 @@ Decoder& Decoder::operator=(Decoder&& other) noexcept
         other.nv12Buffer_ = nullptr;
         other.rgb24Buffer_ = nullptr;
         other.hwInitialized_ = false;
+        other.rawPassthroughMode_ = false;
+        other.rawSwsCtx_ = nullptr;
+        other.rawSwsFrame_ = nullptr;
     }
     return *this;
 }
@@ -458,6 +469,15 @@ void Decoder::initCodecContextWithHwAccel()
     case AV_CODEC_ID_VC1:
         hw_decoder_name = "vc1_cuvid";
         break;
+    case AV_CODEC_ID_RAWVIDEO:
+        // cuvid has no rawvideo codec (there is nothing to decode — rawvideo
+        // is uncompressed pixels). We still want the NVDEC pipeline (GPU-
+        // resident RGB output, ML tensor mode) for raw inputs, so we open the
+        // FFmpeg software rawvideo decoder for parsing/framing. Raw software
+        // frames stay on the producer queue; the consumer thread handles
+        // RGB24 conversion + H2D upload. None of the cuvid setup below applies.
+        initRawPassthrough();
+        return;
     default:
         // No hardware decoder available, will use software with hwaccel
         break;
@@ -543,6 +563,117 @@ void Decoder::initCodecContextWithHwAccel()
     NELUX_DEBUG("CUDA DECODER: Codec opened with hardware acceleration");
 }
 
+void Decoder::initRawPassthrough()
+{
+    NELUX_INFO("CUDA DECODER: rawvideo passthrough requested (no cuvid codec)");
+
+    // Clean up any existing raw-passthrough state (supports reconfigure()).
+    if (rawSwsFrame_)
+        av_frame_free(&rawSwsFrame_);
+    if (rawSwsCtx_)
+    {
+        sws_freeContext(rawSwsCtx_);
+        rawSwsCtx_ = nullptr;
+    }
+    rawPassthroughMode_ = false;
+
+    AVCodecParameters* par = formatCtx->streams[videoStreamIndex]->codecpar;
+    rawPassthroughMode_ = true;
+    NELUX_INFO("CUDA DECODER: rawvideo src_fmt={}",
+               av_get_pix_fmt_name(static_cast<AVPixelFormat>(par->format)));
+    // Open the FFmpeg software rawvideo decoder. It is a near-no-op decoder
+    // (no entropy coding to undo) that just wraps the raw bytes into AVFrames
+    // honoring width/height/format from the container.
+    const AVCodec* codec = avcodec_find_decoder(AV_CODEC_ID_RAWVIDEO);
+    if (!codec)
+    {
+        throw CxException("CUDA DECODER: FFmpeg rawvideo decoder not available");
+    }
+
+    AVCodecContext* codecCtxRaw = avcodec_alloc_context3(codec);
+    if (!codecCtxRaw)
+    {
+        throw CxException("CUDA DECODER: Could not allocate rawvideo codec context");
+    }
+    codecCtx.reset(codecCtxRaw);
+
+    FF_CHECK_MSG(avcodec_parameters_to_context(codecCtx.get(), par),
+                 std::string("Failed to copy rawvideo codec parameters:"));
+
+    // Software decode: no hw_device_ctx, no get_format callback. Keep threads
+    // off — rawvideo is a trivial parser, threading only adds overhead.
+    codecCtx->thread_count = 1;
+    codecCtx->thread_type = 0;
+    codecCtx->time_base = formatCtx->streams[videoStreamIndex]->time_base;
+
+    int ret = avcodec_open2(codecCtx.get(), codec, nullptr);
+    if (ret < 0)
+    {
+        char errbuf[AV_ERROR_MAX_STRING_SIZE];
+        av_strerror(ret, errbuf, sizeof(errbuf));
+        throw CxException(std::string("Failed to open rawvideo codec: ") + errbuf);
+    }
+
+    // No hwframe pool needed: the consumer thread (decodeNextFrame /
+    // decodeNextFrameML) converts to RGB24 and uploads it directly. This avoids
+    // version-dependent hwframe API quirks (for example, CUDA hwcontexts that
+    // do not support RGB software formats).
+}
+
+void Decoder::transferAndConvertRawFrame(AVFrame* frame, void* outputBuffer,
+                                         int outputPitch)
+{
+    if (!rawPassthroughMode_ || !frame || !outputBuffer)
+        throw CxException("CUDA DECODER: Invalid rawvideo conversion request");
+
+    const AVPixelFormat srcFmt = static_cast<AVPixelFormat>(frame->format);
+    const int srcWidth = frame->width;
+    const int srcHeight = frame->height;
+    const int width = properties.width;
+    const int height = properties.height;
+    AVFrame* rgbFrame = frame;
+
+    if (srcFmt != AV_PIX_FMT_RGB24 || srcWidth != width || srcHeight != height)
+    {
+        SwsContext* sws = sws_getCachedContext(
+            rawSwsCtx_, srcWidth, srcHeight, srcFmt, width, height, AV_PIX_FMT_RGB24,
+            SWS_BILINEAR, nullptr, nullptr, nullptr);
+        if (!sws)
+            throw CxException("CUDA DECODER: sws_getCachedContext failed for rawvideo");
+        rawSwsCtx_ = sws;
+
+        if (!rawSwsFrame_ || rawSwsFrame_->width != width ||
+            rawSwsFrame_->height != height)
+        {
+            av_frame_free(&rawSwsFrame_);
+            rawSwsFrame_ = av_frame_alloc();
+            if (!rawSwsFrame_)
+                throw CxException("CUDA DECODER: av_frame_alloc failed for rawvideo");
+            rawSwsFrame_->format = AV_PIX_FMT_RGB24;
+            rawSwsFrame_->width = width;
+            rawSwsFrame_->height = height;
+            if (av_frame_get_buffer(rawSwsFrame_, 0) < 0)
+            {
+                av_frame_free(&rawSwsFrame_);
+                throw CxException("CUDA DECODER: av_frame_get_buffer failed for rawvideo");
+            }
+        }
+        if (av_frame_make_writable(rawSwsFrame_) < 0 ||
+            sws_scale(rawSwsCtx_, frame->data, frame->linesize, 0, srcHeight,
+                      rawSwsFrame_->data, rawSwsFrame_->linesize) != height)
+            throw CxException("CUDA DECODER: Rawvideo conversion failed");
+        rgbFrame = rawSwsFrame_;
+    }
+
+    const int rgbPitch = outputPitch > 0 ? outputPitch : width * 3;
+    cudaError_t err = cudaMemcpy2DAsync(
+        outputBuffer, rgbPitch, rgbFrame->data[0], rgbFrame->linesize[0],
+        width * 3, height, cudaMemcpyHostToDevice, cudaStream_);
+    if (err != cudaSuccess)
+        throw CxException(std::string("CUDA DECODER: Rawvideo upload failed: ") +
+                          cudaGetErrorString(err));
+}
+
 void Decoder::transferAndConvertFrame(AVFrame* hwFrame, void* outputBuffer,
                                       int outputPitch)
 {
@@ -562,6 +693,11 @@ void Decoder::transferAndConvertFrame(AVFrame* hwFrame, void* outputBuffer,
 
     if (hwFrame->format != AV_PIX_FMT_CUDA)
     {
+        if (rawPassthroughMode_)
+        {
+            transferAndConvertRawFrame(hwFrame, outputBuffer, outputPitch);
+            return;
+        }
         throw CxException(
             std::string("CUDA DECODER: Expected CUDA frame format, got ") +
             av_get_pix_fmt_name(static_cast<AVPixelFormat>(hwFrame->format)));
@@ -661,7 +797,8 @@ void Decoder::transferAndConvertFrame(AVFrame* hwFrame, void* outputBuffer,
             av_get_pix_fmt_name(swFormat) +
             "' for GPU color conversion. "
             "Supported formats: NV12, P010LE, P016LE, YUV444P, YUV444P10LE, "
-            "YUV444P12LE, YUV444P16LE. Consider using CPU decoder for this format.");
+            "YUV444P12LE, YUV444P16LE. "
+            "Consider using CPU decoder for this format.");
     }
     }
 
@@ -727,12 +864,12 @@ bool Decoder::decodeNextFrame(void* buffer, double* frame_timestamp)
 
     // Convert and transfer the frame
     // For hardware frames, we use our GPU-side conversion
-    if (frame.get()->format == AV_PIX_FMT_CUDA)
+    if (frame.get()->format == AV_PIX_FMT_CUDA || rawPassthroughMode_)
     {
         // Use intermediate aligned buffer to ensure kernel works correctly
         // and to support writing to unaligned host memory (CPU tensor)
-        int width = frame.get()->width;
-        int height = frame.get()->height;
+        int width = rawPassthroughMode_ ? properties.width : frame.get()->width;
+        int height = rawPassthroughMode_ ? properties.height : frame.get()->height;
         int alignedPitch = (width * 3 + 255) & ~255;
         size_t alignedSize = alignedPitch * height;
 
@@ -877,6 +1014,18 @@ void Decoder::close()
         rgb24Buffer_ = nullptr;
         rgb24BufferSize_ = 0;
     }
+
+    // Release rawvideo-passthrough resources.
+    if (rawSwsFrame_)
+    {
+        av_frame_free(&rawSwsFrame_);
+    }
+    if (rawSwsCtx_)
+    {
+        sws_freeContext(rawSwsCtx_);
+        rawSwsCtx_ = nullptr;
+    }
+    rawPassthroughMode_ = false;
 
     // Release hardware device context
     if (hwDeviceCtx_)
@@ -1056,7 +1205,7 @@ bool Decoder::decodeNextFrameML(void* buffer, double* frame_timestamp)
     std::lock_guard<std::mutex> guard(cudaDecodeMutex_);
 
     // Convert and transfer the frame using unified two-step approach
-    if (frame.get()->format == AV_PIX_FMT_CUDA)
+    if (frame.get()->format == AV_PIX_FMT_CUDA || rawPassthroughMode_)
     {
         // Unified two-step conversion for ALL formats:
         // Step 1: Convert any format (NV12, P010, YUV444, etc.) to RGB24 using existing
@@ -1068,9 +1217,13 @@ bool Decoder::decodeNextFrameML(void* buffer, double* frame_timestamp)
         // - Negligible performance cost (~20 microseconds vs direct path)
 
         // Step 1: Check format and choose path
-        AVHWFramesContext* hwFramesCtx =
-            (AVHWFramesContext*)frame.get()->hw_frames_ctx->data;
-        AVPixelFormat swFormat = hwFramesCtx->sw_format;
+        AVPixelFormat swFormat = AV_PIX_FMT_NONE;
+        if (frame.get()->format == AV_PIX_FMT_CUDA)
+        {
+            AVHWFramesContext* hwFramesCtx =
+                (AVHWFramesContext*)frame.get()->hw_frames_ctx->data;
+            swFormat = hwFramesCtx->sw_format;
+        }
 
         // RGBA32 Path for NV12 (Fixes alignment stripes)
         if (swFormat == AV_PIX_FMT_NV12)
@@ -1115,8 +1268,8 @@ bool Decoder::decodeNextFrameML(void* buffer, double* frame_timestamp)
         else
         {
             // Legacy/Fallback Path for P010, P016 etc.
-            int width = frame.get()->width;
-            int height = frame.get()->height;
+            int width = rawPassthroughMode_ ? properties.width : frame.get()->width;
+            int height = rawPassthroughMode_ ? properties.height : frame.get()->height;
             int rgbPitch = (width * 3 + 255) & ~255;
             size_t rgb24Size = rgbPitch * height;
 

--- a/src/Nelux/python/VideoReader.cpp
+++ b/src/Nelux/python/VideoReader.cpp
@@ -57,49 +57,19 @@ VideoReader::VideoReader(const std::string& filePath, int numThreads, bool force
                 ? torch::Device(torch::kCUDA, cuda_device_index)
                 : torch::Device(torch::kCPU);
 
-        // Main sequential decoder with fallback logic
-        if (decodeAccelerator == nelux::DecodeAccelerator::NVDEC)
-        {
-            try
-            {
-                // Try NVDEC first
-                decoder = nelux::Factory::createDecoder(
-                    torchDevice, filePath, numThreads, decodeAccelerator,
-                    cuda_device_index, resizeWidth_, resizeHeight_);
-                decoder->setForce8Bit(force_8bit);
-                NELUX_INFO("Main decoder created successfully with accelerator: {}",
-                           decode_accelerator);
-            }
-            catch (const std::exception& nvdec_ex)
-            {
-                // NVDEC failed - fall back to CPU decoder
-                NELUX_WARN("NVDEC decoder failed: {}. Falling back to CPU decoder.",
-                           nvdec_ex.what());
-
-                // Update internal state to reflect CPU fallback
-                decodeAccelerator = nelux::DecodeAccelerator::CPU;
-                torchDevice = torch::Device(torch::kCPU);
-
-                decoder = nelux::Factory::createDecoder(
-                    torchDevice, filePath, numThreads, nelux::DecodeAccelerator::CPU, 0,
-                    resizeWidth_, resizeHeight_);
-                decoder->setForce8Bit(force_8bit);
-                NELUX_INFO("Fallback to CPU decoder successful after NVDEC failure");
-            }
-        }
-        else
-        {
-            // Direct CPU decoder path. Sync mode is opt-in; bypasses the
-            // producer thread / queue for raw single-stream throughput.
-            const bool syncMode =
-                !prefetch && decodeAccelerator == nelux::DecodeAccelerator::CPU;
-            decoder = nelux::Factory::createDecoder(
-                torchDevice, filePath, numThreads, decodeAccelerator, cuda_device_index,
-                resizeWidth_, resizeHeight_, syncMode);
-            decoder->setForce8Bit(force_8bit);
-            NELUX_INFO("Main decoder created successfully with accelerator: {}",
-                       decode_accelerator);
-        }
+        // Main sequential decoder. NVDEC failures are surfaced as hard errors
+        // rather than silently downgraded to CPU: the caller explicitly asked
+        // for hardware decode and silent fallback has historically masked
+        // configuration mistakes (wrong device, missing codec support, etc.).
+        // Set decode_accelerator='cpu' explicitly to opt into software decode.
+        const bool syncMode =
+            !prefetch && decodeAccelerator == nelux::DecodeAccelerator::CPU;
+        decoder = nelux::Factory::createDecoder(
+            torchDevice, filePath, numThreads, decodeAccelerator, cuda_device_index,
+            resizeWidth_, resizeHeight_, syncMode);
+        decoder->setForce8Bit(force_8bit);
+        NELUX_INFO("Main decoder created successfully with accelerator: {}",
+                   decode_accelerator);
 
         // Apply user-supplied convert_workers override before any decode
         // call spawns the worker pool (lazy-start in startSyncConvertWorkers).
@@ -258,55 +228,32 @@ torch::Tensor VideoReader::decodeFrame()
     bool success = false;
     torch::Tensor outTensor;  // populated by zero-copy CPU path
 
-    // Retry loop. A one-shot NVDEC->CPU fallback re-runs the decode by looping
-    // rather than recursing: recursing would call decodeFrame() while this
-    // scope's gil_scoped_release is still active, constructing a second release
-    // with the GIL already dropped — undefined behavior (PyEval_SaveThread on a
-    // NULL thread state). After the fallback the accelerator is CPU, so a
-    // second failure rethrows and the loop cannot spin.
-    while (true)
+    // No silent NVDEC->CPU fallback: if hardware decode fails mid-stream we
+    // surface the error to the caller. Silent fallback was removed because it
+    // masked configuration errors and silently switched output devices/tensor
+    // layouts under the caller's feet. Use decode_accelerator='cpu' to opt in
+    // to software decode explicitly.
+    try
     {
-        try
+        if (decodeAccelerator == nelux::DecodeAccelerator::CPU)
         {
-            if (decodeAccelerator == nelux::DecodeAccelerator::CPU)
-            {
-                outTensor = prefetch
-                                ? decoder->decodeNextFrameTensor(&frame_timestamp)
-                                : decoder->decodeNextFrameTensorSync(&frame_timestamp);
-                success = outTensor.defined();
-            }
-            else
-            {
-                // NVDEC / hardware path: in-place write into shared CUDA tensor.
-                success = decoder->decodeNextFrame(tensor.data_ptr(), &frame_timestamp);
-            }
-            break; // decode attempt finished (frame produced or clean EOF)
+            outTensor = prefetch
+                            ? decoder->decodeNextFrameTensor(&frame_timestamp)
+                            : decoder->decodeNextFrameTensorSync(&frame_timestamp);
+            success = outTensor.defined();
         }
-        catch (const std::exception& ex)
+        else
         {
-            std::cerr << "VideoReader: Exception caught: " << ex.what() << std::endl;
-            // If NVDEC fails mid-iteration, fall back to CPU.
-            if (decodeAccelerator == nelux::DecodeAccelerator::NVDEC)
-            {
-                NELUX_WARN("decodeFrame(): NVDEC failed: {}. Falling back to CPU decoder.",
-                           ex.what());
-
-                decodeAccelerator = nelux::DecodeAccelerator::CPU;
-                decoder = nelux::Factory::createDecoder(
-                    torch::Device(torch::kCPU), filePath, numThreads, decodeAccelerator, 0,
-                    resizeWidth_, resizeHeight_);
-                decoder->setForce8Bit(force_8bit);
-
-                // Recreate output tensor on CPU with HWC format
-                torch::Dtype torchDataType = findTypeFromBitDepth();
-                tensor = torch::empty(
-                    {properties.height, properties.width, 3},
-                    torch::TensorOptions().dtype(torchDataType).device(torch::kCPU));
-
-                continue; // retry with CPU path, no recursion
-            }
-            throw;
+            // NVDEC / hardware path: in-place write into shared CUDA tensor.
+            success = decoder->decodeNextFrame(tensor.data_ptr(), &frame_timestamp);
         }
+    }
+    catch (const std::exception& ex)
+    {
+        NELUX_ERROR("decodeFrame(): decoder failed: {}. "
+                    "Set decode_accelerator='cpu' to use software decode.",
+                    ex.what());
+        throw;
     }
     
     if (!success)
@@ -649,35 +596,14 @@ void VideoReader::ensureRandDecoder()
             (decodeAccelerator == nelux::DecodeAccelerator::NVDEC)
                 ? torch::Device(torch::kCUDA, cudaDeviceIndex)
                 : torch::Device(torch::kCPU);
-        
-        if (decodeAccelerator == nelux::DecodeAccelerator::NVDEC)
-        {
-            try
-            {
-                // Try NVDEC first for random decoder too
-                rand_decoder = nelux::Factory::createDecoder(
-                    torchDevice, filePath, numThreads, decodeAccelerator,
-                    cudaDeviceIndex, resizeWidth_, resizeHeight_);
-                rand_decoder->setForce8Bit(force_8bit);
-            }
-            catch (const std::exception& nvdec_ex)
-            {
-                // NVDEC failed - fall back to CPU decoder for random access
-                NELUX_WARN("NVDEC rand_decoder failed: {}. Falling back to CPU.",
-                           nvdec_ex.what());
-                rand_decoder = nelux::Factory::createDecoder(
-                    torch::Device(torch::kCPU), filePath, numThreads,
-                    nelux::DecodeAccelerator::CPU, 0, resizeWidth_, resizeHeight_);
-                rand_decoder->setForce8Bit(force_8bit);
-            }
-        }
-        else
-        {
-            rand_decoder = nelux::Factory::createDecoder(
-                torchDevice, filePath, numThreads, decodeAccelerator, cudaDeviceIndex,
-                resizeWidth_, resizeHeight_);
-            rand_decoder->setForce8Bit(force_8bit);
-        }
+
+        // No silent NVDEC->CPU fallback for the random-access decoder either.
+        // A failure here surfaces as a hard error consistent with the main
+        // decoder path; use decode_accelerator='cpu' for software decode.
+        rand_decoder = nelux::Factory::createDecoder(
+            torchDevice, filePath, numThreads, decodeAccelerator, cudaDeviceIndex,
+            resizeWidth_, resizeHeight_);
+        rand_decoder->setForce8Bit(force_8bit);
     }
 }
 

--- a/tests/test_rawvideo_nvdec.py
+++ b/tests/test_rawvideo_nvdec.py
@@ -1,0 +1,182 @@
+"""
+Tests for rawvideo input on the NVDEC decoder path.
+
+Verifies that:
+  1. rawvideo (YUV420P and RGB24) inputs open successfully with
+     decode_accelerator='nvdec'.
+  2. The output tensor lives on the CUDA device.
+  3. Pixel values match the CPU decoder reference within an acceptable
+     tolerance (YUV paths: small rounding diff from the CPU-vs-GPU sws path;
+     RGB path: exact match after lossless RGB24 conversion).
+  4. Iterating multiple frames works without error.
+
+Test clips are generated on the fly and do not depend on repo fixtures.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import torch  # noqa: E402  -- must precede nelux
+
+import nelux
+
+BUNDLED_FFMPEG = (
+    Path(__file__).resolve().parent.parent / "external" / "ffmpeg" / "bin" / "ffmpeg.exe"
+)
+FFMPEG = str(BUNDLED_FFMPEG) if BUNDLED_FFMPEG.exists() else shutil.which("ffmpeg")
+WIDTH, HEIGHT, NUM_FRAMES = 128, 96, 12
+
+
+def _have_cuda() -> bool:
+    try:
+        import torch
+
+        return torch.cuda.is_available()
+    except Exception:
+        return False
+
+
+def _generate_rawvideo_clip(path: Path, pix_fmt: str) -> None:
+    """Generate a small rawvideo clip wrapped in AVI for the given pix_fmt."""
+    if not FFMPEG:
+        pytest.skip("ffmpeg is required to generate rawvideo test clips")
+    if path.exists():
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        FFMPEG,
+        "-y",
+        "-f",
+        "lavfi",
+        "-i",
+        f"testsrc=duration=1:size={WIDTH}x{HEIGHT}:rate={NUM_FRAMES}",
+        "-frames:v",
+        str(NUM_FRAMES),
+        "-c:v",
+        "rawvideo",
+        "-pix_fmt",
+        pix_fmt,
+        str(path),
+    ]
+    subprocess.run(cmd, check=True, capture_output=True)
+
+
+@pytest.fixture(scope="module")
+def rawvideo_dir(tmp_path_factory):
+    return tmp_path_factory.mktemp("rawvideo_nvdec")
+
+
+@pytest.fixture(scope="module")
+def yuv420p_clip(rawvideo_dir):
+    path = rawvideo_dir / "raw_nvdec_yuv420p.avi"
+    _generate_rawvideo_clip(path, "yuv420p")
+    return str(path)
+
+
+@pytest.fixture(scope="module")
+def rgb24_clip(rawvideo_dir):
+    path = rawvideo_dir / "raw_nvdec_rgb24.avi"
+    _generate_rawvideo_clip(path, "rgb24")
+    return str(path)
+
+
+@pytest.fixture(scope="module")
+def bgr0_clip(rawvideo_dir):
+    path = rawvideo_dir / "raw_nvdec_bgr0.avi"
+    _generate_rawvideo_clip(path, "bgr0")
+    return str(path)
+
+
+def _read_first_frames(path: str, accelerator: str, count: int = 4):
+    """Open *path* and read *count* frames, returning a list of tensors."""
+    reader = nelux.VideoReader(path, decode_accelerator=accelerator)
+    frames = []
+    for _ in range(count):
+        f = reader.read_frame()
+        if f is None:
+            break
+        frames.append(f.clone())
+    del reader
+    return frames
+
+
+# --------------------------------------------------------------------------
+# NVDEC path tests (skipped if no CUDA)
+# --------------------------------------------------------------------------
+
+skip_no_cuda = pytest.mark.skipif(not _have_cuda(), reason="CUDA not available")
+
+
+@skip_no_cuda
+def test_rawvideo_yuv420p_nvdec_opens(yuv420p_clip):
+    """rawvideo + YUV420P opens on NVDEC without falling back to CPU."""
+    import torch
+
+    frames = _read_first_frames(yuv420p_clip, "nvdec", count=2)
+    assert len(frames) >= 1
+    assert frames[0].device.type == "cuda"
+    assert frames[0].shape == (HEIGHT, WIDTH, 3)
+
+
+@skip_no_cuda
+def test_rawvideo_yuv420p_nvdec_vs_cpu(yuv420p_clip):
+    """NVDEC output is close to CPU reference for YUV420P raw."""
+    import torch
+
+    cpu_frames = _read_first_frames(yuv420p_clip, "cpu", count=4)
+    nv_frames = _read_first_frames(yuv420p_clip, "nvdec", count=4)
+    assert len(cpu_frames) == len(nv_frames)
+    for cpu_f, nv_f in zip(cpu_frames, nv_frames):
+        cpu_on_gpu = cpu_f.to(nv_f.device).to(nv_f.dtype)
+        max_diff = (cpu_on_gpu.int() - nv_f.int()).abs().max().item()
+        # YUV420P -> RGB via different sws paths can differ by a few LSB.
+        assert max_diff <= 5, f"max pixel diff {max_diff} exceeds tolerance"
+
+
+@skip_no_cuda
+def test_rawvideo_rgb24_nvdec_lossless(rgb24_clip):
+    """RGB24 raw passthrough is pixel-exact vs CPU."""
+    import torch
+
+    cpu_frames = _read_first_frames(rgb24_clip, "cpu", count=4)
+    nv_frames = _read_first_frames(rgb24_clip, "nvdec", count=4)
+    assert len(cpu_frames) == len(nv_frames)
+    for cpu_f, nv_f in zip(cpu_frames, nv_frames):
+        cpu_on_gpu = cpu_f.to(nv_f.device).to(nv_f.dtype)
+        max_diff = (cpu_on_gpu.int() - nv_f.int()).abs().max().item()
+        assert max_diff == 0, f"RGB lossless check failed, max_diff={max_diff}"
+
+
+@skip_no_cuda
+def test_rawvideo_bgr0_nvdec_lossless(bgr0_clip):
+    """BGR0 raw passthrough is pixel-exact after channel swap."""
+    import torch
+
+    cpu_frames = _read_first_frames(bgr0_clip, "cpu", count=4)
+    nv_frames = _read_first_frames(bgr0_clip, "nvdec", count=4)
+    assert len(cpu_frames) == len(nv_frames)
+    for cpu_f, nv_f in zip(cpu_frames, nv_frames):
+        cpu_on_gpu = cpu_f.to(nv_f.device).to(nv_f.dtype)
+        max_diff = (cpu_on_gpu.int() - nv_f.int()).abs().max().item()
+        assert max_diff == 0, f"BGR0 lossless check failed, max_diff={max_diff}"
+
+
+@skip_no_cuda
+def test_rawvideo_nvdec_iteration(yuv420p_clip):
+    """Iterating the reader yields multiple frames without error."""
+    reader = nelux.VideoReader(yuv420p_clip, decode_accelerator="nvdec")
+    count = 0
+    for frame in reader:
+        assert frame.device.type == "cuda"
+        count += 1
+        if count >= NUM_FRAMES:
+            break
+    del reader
+    assert count >= 4
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
## Summary
- route `AV_CODEC_ID_RAWVIDEO` through FFmpeg's rawvideo decoder when `decode_accelerator="nvdec"`
- convert software raw frames to RGB24, resize when requested, and upload into the CUDA output path
- surface NVDEC failures instead of silently changing device/layout via CPU fallback
- add generated YUV420P, RGB24, and BGR0 coverage

## Validation
- CUDA/MSVC build succeeds
- `python -m pytest tests/test_rawvideo_nvdec.py -q -p no:cacheprovider` (5 passed)
- rawvideo resize smoke test `(128x96 -> 64x48)` succeeds