### PR TITLE
feat: make PyTorch optional for the NumPy decode backend (Windows)

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -213,13 +213,20 @@ jobs:
           # inflating the wheel ~100 MB. We scan BOTH torch/lib and the CUDA
           # toolkit bin because the dep walker may pick up either copy depending
           # on PATH ordering, and they may have different minor versions.
+          # NOTE: c10.dll is deliberately NOT excluded -- it is bundled into the
+          # wheel so the torch-free NumPy backend imports and decodes with PyTorch
+          # not installed. c10.dll cannot be delay-loaded (data-symbol import,
+          # LNK1194) and depends only on the system CRT, so it is self-contained.
+          # torch_cpu/torch_python/torch are delay-loaded and resolved from the
+          # user's own PyTorch install when the PyTorch backend runs, so they stay
+          # excluded (must match the user's torch ABI).
           $CudaPatterns = @(
             "cudart64_*.dll", "nvrtc64_*.dll", "nvrtc-builtins64_*.dll",
             "cufft64_*.dll", "curand64_*.dll", "cusolver64_*.dll",
             "cusparse64_*.dll", "cublas64_*.dll", "cublasLt64_*.dll",
             "cudnn*64_*.dll", "nvToolsExt64_*.dll", "caffe2_nvrtc.dll",
             "torch.dll", "torch_cpu.dll", "torch_cuda.dll",
-            "torch_python.dll", "c10.dll", "c10_cuda.dll", "shm.dll"
+            "torch_python.dll", "c10_cuda.dll", "shm.dll"
           )
           $ScanDirs = @($TorchLib)
           if ($env:CUDA_PATH -and (Test-Path (Join-Path $env:CUDA_PATH 'bin'))) {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -539,6 +539,32 @@ if(NELUX_BUILD_PYTHON)
       endif()
     endforeach()
     message(STATUS "MSVC: FFmpeg DLLs will be delay-loaded for version flexibility")
+
+    # Delay-load the core PyTorch runtime (torch_cpu/c10/torch_python) so the
+    # module IMPORTS even when PyTorch is not installed at all. The NumPy backend
+    # decodes through a fully torch-free path (VideoReader's decodeNextFrameBufferSync
+    # / bufferToNumpy), so none of these symbols is referenced unless the caller
+    # actually selects the PyTorch backend (or NVDEC) and requests a frame -- at
+    # which point the delay-load thunk resolves them from the user's installed
+    # torch. Without this they are eager import-table entries and `import nelux`
+    # fails with WinError 126 when torch is absent. torch.dll carries no
+    # referenced symbols in the import table; it is listed defensively (benign
+    # LNK4199 if unused). delayimp.lib is linked just above.
+    #
+    # NOTE (Linux): the equivalent decoupling would require lazy/-z-now-off
+    # binding of libtorch_cpu/libc10; not attempted here. On Linux torch remains
+    # a load-time (DT_NEEDED) dependency.
+    # NOTE: c10.dll CANNOT be delay-loaded -- libtorch headers reference a c10
+    # *data* symbol (e.g. caffe2::detail ...metadata_index), and the delay-load
+    # thunk mechanism only intercepts function imports, not data imports
+    # (LNK1194). So c10.dll stays a load-time dependency; torch_cpu/torch_python/
+    # torch are delay-loaded and resolve only when the PyTorch backend runs.
+    target_link_options(nelux PRIVATE
+      "/DELAYLOAD:torch_cpu.dll"
+      "/DELAYLOAD:torch_python.dll"
+      "/DELAYLOAD:torch.dll"
+    )
+    message(STATUS "MSVC: torch_cpu/torch_python/torch delay-loaded (c10.dll stays load-time: data-symbol import)")
   endif()
 
   if(NELUX_ENABLE_CUDA)
@@ -688,6 +714,27 @@ if(WIN32 AND NELUX_BUILD_PYTHON)
     endif()
   else()
     message(STATUS "NELUX_BUNDLE_FFMPEG_DLLS=OFF, skipping FFmpeg runtime DLL bundling")
+  endif()
+
+  # Bundle c10.dll -- the ONE torch runtime DLL that cannot be delay-loaded (it
+  # is referenced via a data symbol, see the /DELAYLOAD block above). Shipping it
+  # inside the wheel lets the NumPy backend import and decode with PyTorch NOT
+  # installed at all. c10.dll depends only on the system CRT (no other torch DLL),
+  # so it is fully self-contained. torch_cpu/torch_python are delay-loaded and
+  # resolved from the user's own PyTorch install when the PyTorch backend runs,
+  # so they are intentionally NOT bundled (and must match the wheel's torch ABI).
+  if(NELUX_PYTORCH_LIBDIR)
+    # NELUX_PYTORCH_LIBDIR comes from torch.__path__ and may use native (back)slashes;
+    # normalize to a CMake path so the generated install script doesn't choke on
+    # backslash escapes (e.g. '\N' in D:\Nelux...).
+    file(TO_CMAKE_PATH "${NELUX_PYTORCH_LIBDIR}/c10.dll" _nelux_c10_dll)
+    if(EXISTS "${_nelux_c10_dll}")
+      list(APPEND NELUX_DLLS "${_nelux_c10_dll}")
+      message(STATUS "Bundling c10.dll for the torch-free NumPy backend: ${_nelux_c10_dll}")
+    else()
+      message(WARNING "c10.dll not found at '${_nelux_c10_dll}'; the NumPy backend "
+                      "will require c10.dll on the DLL search path at runtime")
+    endif()
   endif()
 
   # Deduplicate in case multiple glob sources overlap

--- a/include/Nelux/backends/Decoder.hpp
+++ b/include/Nelux/backends/Decoder.hpp
@@ -84,6 +84,13 @@ class Decoder
     // decoder before any decode call.
     virtual torch::Tensor decodeNextFrameTensorSync(double* frame_timestamp = nullptr);
 
+    // Torch-free sibling of decodeNextFrameTensorSync used by the NumPy backend.
+    // Drives the codec single-threaded (no worker pool, no torch::Tensor) and
+    // returns the converted RGB frame as a raw pooled byte buffer, or nullptr at
+    // EOF. Lets the NumPy path decode without touching any torch/c10 symbol so
+    // `import nelux` works with PyTorch absent (torch DLLs are delay-loaded).
+    std::unique_ptr<uint8_t[]> decodeNextFrameBufferSync(double* frame_timestamp = nullptr);
+
     // Toggle synchronous decode mode. When true, the producer thread is never
     // started; callers must use decodeNextFrameTensorSync(). Must be set
     // before the first decode call.

--- a/include/Nelux/python/VideoReader.hpp
+++ b/include/Nelux/python/VideoReader.hpp
@@ -129,11 +129,14 @@ class VideoReader
     std::string getFrameType() const;
 
     /**
-     * @brief Internal method to decode the next frame into the internal tensor buffer.
+     * @brief Internal method to decode the next frame.
      *
-     * @return torch::Tensor The decoded frame as torch::Tensor (internal use).
+     * Returns the frame already wrapped as a Python object (torch.Tensor for the
+     * PyTorch backend, numpy.ndarray for the NumPy backend), or py::none() at
+     * EOF. Keeping the backend branch here lets the NumPy CPU path avoid ever
+     * constructing a torch::Tensor, so it references no torch/c10 symbol.
      */
-    torch::Tensor decodeFrame();
+    py::object decodeFrame();
 
     /**
      * @brief Seek to a specific timestamp in the video.
@@ -381,6 +384,17 @@ class VideoReader
     {
         return (properties.fps > 0.0) ? 1.0 / properties.fps : 0.0;
     }
+
+    // True when the main decoder runs the synchronous frame-threaded CPU path
+    // (no async producer). Seeking such a context via avcodec_flush_buffers
+    // trips an internal FFmpeg assertion, so iter() skips redundant flush-seeks
+    // here. The NumPy backend always forces sync mode (see the constructor), so
+    // it counts as sync regardless of the prefetch flag.
+    bool isCpuSyncPath() const
+    {
+        return decodeAccelerator == nelux::DecodeAccelerator::CPU &&
+               (!prefetch || backend == Backend::NumPy);
+    }
     std::shared_ptr<nelux::Decoder> rand_decoder;
 
     torch::Tensor makeLikeOutputTensor() const;
@@ -398,20 +412,33 @@ class VideoReader
     py::object tensorToOutput(const torch::Tensor& t) const;
 
     /**
+     * @brief Wrap a raw pooled RGB byte buffer as a numpy.ndarray (HWC), zero-copy
+     * and torch-free (pybind11 only; a capsule delete[]s the buffer on GC). Used
+     * exclusively by the NumPy backend.
+     */
+    py::object bufferToNumpy(std::unique_ptr<uint8_t[]> buf) const;
+
+    /**
+     * @brief Backend-appropriate empty frame (EOF sentinel surfaced to Python):
+     * an empty (0, W, 3) numpy array for NumPy, an undefined tensor for PyTorch.
+     */
+    py::object emptyFrame() const;
+
+    /**
      * @brief Internal method to decode frame at timestamp using rand_decoder.
      *
      * @param timestamp_seconds Timestamp in seconds.
-     * @return torch::Tensor The decoded frame.
+     * @return py::object The decoded frame (torch.Tensor or numpy.ndarray).
      */
-    torch::Tensor decodeFrameAt(double timestamp_seconds);
+    py::object decodeFrameAt(double timestamp_seconds);
 
     /**
      * @brief Internal method to decode frame at index using rand_decoder.
      *
      * @param frame_index Frame index.
-     * @return torch::Tensor The decoded frame.
+     * @return py::object The decoded frame (torch.Tensor or numpy.ndarray).
      */
-    torch::Tensor decodeFrameAt(int frame_index);
+    py::object decodeFrameAt(int frame_index);
 
     // Member variables
     std::shared_ptr<nelux::Decoder> decoder;
@@ -435,7 +462,7 @@ class VideoReader
     int rangeFrameLimit_ = -1;
     int rangeFramesEmitted_ = 0;
     // List of filters to be added before initialization
-    torch::Tensor bufferedFrame; // The "first valid" frame, if we found it early
+    py::object bufferedFrame; // The "first valid" frame, if we found it early
     bool hasBufferedFrame = false;
 
     // Lazy loading support

--- a/include/Nelux/python/VideoReader.hpp
+++ b/include/Nelux/python/VideoReader.hpp
@@ -4,6 +4,7 @@
 #include "Decoder.hpp"
 #include "Factory.hpp"
 #include <VideoEncoder.hpp>
+#include <optional>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 
@@ -444,7 +445,12 @@ class VideoReader
     std::shared_ptr<nelux::Decoder> decoder;
     nelux::Decoder::VideoProperties properties;
 
-    torch::Tensor tensor;
+    // Shared output tensor for the PyTorch backend / NVDEC in-place write. Held
+    // in an optional so the NumPy CPU path leaves it disengaged: even the
+    // at::Tensor default constructor is an exported torch_cpu symbol, so a bare
+    // `torch::Tensor tensor;` member would fire a torch_cpu delay-load thunk on
+    // every reader and break the NumPy backend when PyTorch is absent.
+    std::optional<torch::Tensor> tensor;
 
     // Variables for frame range
     int start_frame = 0;

--- a/nelux/__init__.py
+++ b/nelux/__init__.py
@@ -6,29 +6,57 @@ Nelux - High-performance video decoding and encoding library.
 import os
 import sys
 import ctypes
+import importlib.util
 from typing import Dict, List
 
-# Check for PyTorch first
-if "torch" not in sys.modules:
-    raise ImportError(
-        "PyTorch must be imported before Nelux.\n"
-        "Add this before importing nelux:\n"
-        "  import torch"
-    )
+# NOTE: PyTorch is NOT required to import nelux. The compiled extension
+# delay-loads the torch runtime DLLs (torch_cpu/c10/torch_python), so `import
+# nelux` succeeds even when PyTorch is not installed. torch is imported lazily
+# only when the PyTorch decode backend (or NVDEC) is actually used and a frame
+# is requested -- see _ensure_torch() and VideoReader below. The NumPy backend
+# is fully torch-free.
+
+
+def _find_torch_lib_dir() -> "str | None":
+    """Locate the installed torch's ``lib`` directory WITHOUT importing torch.
+
+    ``find_spec`` reads torch's module spec but never executes its ``__init__``,
+    so this does not pull torch into ``sys.modules``. Returns None when torch is
+    not installed (the NumPy backend needs no torch)."""
+    try:
+        spec = importlib.util.find_spec("torch")
+    except (ImportError, ValueError):
+        return None
+    if spec is None or not spec.origin:
+        return None
+    lib_dir = os.path.join(os.path.dirname(spec.origin), "lib")
+    return lib_dir if os.path.isdir(lib_dir) else None
+
 
 # Setup DLL paths on Windows
 if os.name == "nt":
     package_dir = os.path.dirname(os.path.abspath(__file__))
     libs_dir = os.path.join(package_dir, "nelux.libs")
 
+    # torch's lib dir is added best-effort so the delay-loaded torch DLLs resolve
+    # if/when the PyTorch backend is used. Absent torch -> skipped (NumPy works).
+    _torch_lib_dir = _find_torch_lib_dir()
+
     if hasattr(os, "add_dll_directory"):
         os.add_dll_directory(package_dir)
         if os.path.exists(libs_dir):
             os.add_dll_directory(libs_dir)
+        if _torch_lib_dir:
+            try:
+                os.add_dll_directory(_torch_lib_dir)
+            except OSError:
+                pass
     else:
         path_entries = [package_dir]
         if os.path.exists(libs_dir):
             path_entries.append(libs_dir)
+        if _torch_lib_dir:
+            path_entries.append(_torch_lib_dir)
         os.environ["PATH"] = ";".join(path_entries) + ";" + os.environ["PATH"]
 
 
@@ -249,16 +277,42 @@ except ImportError as e:
         ) from e
     raise
 
-_torch_version = sys.modules["torch"].__version__.split("+", 1)[0].split(".")[:2]
-_torch_abi = ".".join(_torch_version)
-if __torch_abi__ != "unknown" and _torch_abi != __torch_abi__:
-    raise ImportError(
-        f"This Nelux wheel was built for PyTorch {__torch_abi__}.x, "
-        f"but the imported PyTorch is {sys.modules['torch'].__version__}. "
-        "Install the Nelux wheel tagged for your PyTorch minor version."
-    )
+_torch_abi_verified = False
 
-# Import batch mixin
+
+def _ensure_torch():
+    """Import PyTorch lazily and verify ABI compatibility, once.
+
+    Called only when the PyTorch decode backend (or NVDEC) is actually used, so
+    a pure NumPy workflow never triggers a torch import. Raises a clear error if
+    torch is missing or its minor version does not match the ABI this wheel was
+    built against.
+    """
+    global _torch_abi_verified
+    try:
+        import torch
+    except ImportError as e:
+        raise ImportError(
+            "The PyTorch backend requires PyTorch, but it is not installed.\n"
+            "Install a matching PyTorch build, or use the torch-free NumPy "
+            "backend:\n"
+            "    nelux.VideoReader(path, backend='numpy')"
+        ) from e
+
+    if not _torch_abi_verified:
+        _torch_abi_verified = True
+        if __torch_abi__ != "unknown":
+            _tv = torch.__version__.split("+", 1)[0].split(".")[:2]
+            if ".".join(_tv) != __torch_abi__:
+                raise ImportError(
+                    f"This Nelux wheel was built for PyTorch {__torch_abi__}.x, "
+                    f"but the installed PyTorch is {torch.__version__}. "
+                    "Install the Nelux wheel tagged for your PyTorch minor version."
+                )
+    return torch
+
+
+# Import batch mixin (torch-free at import time; batch.py imports torch lazily)
 from .batch import BatchMixin
 
 
@@ -266,17 +320,28 @@ class VideoReader(BatchMixin, _VideoReaderBase):
     """VideoReader with batch frame reading support."""
 
     def __init__(self, *args, **kwargs):
-        # NVDEC needs a CUDA-capable, *active* PyTorch. The CUDA runtime is
-        # delay-loaded so the module imports on CPU-only torch; guard here so
-        # requesting nvdec on a CPU/GPU-less torch raises a clear error up front
-        # instead of failing deep in the decoder. torch.cuda.is_available() is
-        # safe on CPU torch (returns False without needing c10_cuda).
+        # Resolve backend/accelerator WITHOUT importing torch. Positional order:
+        # input_path, num_threads, force_8bit, backend, decode_accelerator, ...
+        backend = kwargs.get("backend")
+        if backend is None and len(args) >= 4:
+            backend = args[3]
+        backend = backend if isinstance(backend, str) else "pytorch"
+
         accel = kwargs.get("decode_accelerator")
         if accel is None and len(args) >= 5:
-            accel = args[4]  # input_path, num_threads, force_8bit, backend, decode_accelerator
-        if isinstance(accel, str) and accel.lower() == "nvdec":
-            import torch
+            accel = args[4]
+        accel = accel if isinstance(accel, str) else "cpu"
 
+        is_numpy = backend.lower() == "numpy"
+        is_nvdec = accel.lower() == "nvdec"
+
+        if is_nvdec:
+            # NVDEC needs a CUDA-capable, *active* PyTorch regardless of output
+            # backend. The CUDA runtime is delay-loaded so the module imports on
+            # CPU-only torch; guard here so requesting nvdec on a CPU/GPU-less
+            # torch raises a clear error up front instead of failing deep in the
+            # decoder. torch.cuda.is_available() is safe on CPU torch.
+            torch = _ensure_torch()
             if not torch.cuda.is_available():
                 raise RuntimeError(
                     "decode_accelerator='nvdec' requires a CUDA-enabled PyTorch "
@@ -284,7 +349,17 @@ class VideoReader(BatchMixin, _VideoReaderBase):
                     "(CPU-only PyTorch or no NVIDIA GPU). Use "
                     "decode_accelerator='cpu', or install a CUDA build of PyTorch."
                 )
+        elif not is_numpy:
+            # PyTorch output backend on CPU: the C++ constructor allocates a
+            # torch::Tensor and frames are returned as torch.Tensor, so torch
+            # must be imported (and ABI-checked) before decoding starts. The
+            # NumPy backend is intentionally skipped here and stays torch-free.
+            _ensure_torch()
+
         super().__init__(*args, **kwargs)
+        # Remember the resolved backend so BatchMixin.get_batch can stay
+        # torch-free for the NumPy backend (a Python-subclass __dict__ attr).
+        self._nelux_backend = "numpy" if is_numpy else "pytorch"
 
 
 __all__ = [

--- a/nelux/batch.py
+++ b/nelux/batch.py
@@ -1,8 +1,18 @@
 """Batch frame reading support for VideoReader."""
 
+import sys
 import numpy as np
-import torch
 from typing import Union, List
+
+
+def _torch_module():
+    """Return the already-imported torch module, or None.
+
+    Never imports torch: if the caller is passing a torch.Tensor (or using the
+    PyTorch backend) torch is necessarily already in sys.modules. This keeps the
+    NumPy backend fully torch-free.
+    """
+    return sys.modules.get("torch")
 
 
 class BatchMixin:
@@ -14,6 +24,9 @@ class BatchMixin:
     - Sorting frames in sequential order
     - Only seeking when necessary (backward jumps or large gaps)
     """
+
+    def _is_numpy_backend(self) -> bool:
+        return getattr(self, "_nelux_backend", "pytorch") == "numpy"
 
     def _to_index_list(self, indices) -> List[int]:
         """
@@ -41,8 +54,10 @@ class BatchMixin:
         if isinstance(indices, range):
             return list(indices)
 
-        # Handle torch tensors
-        if isinstance(indices, torch.Tensor):
+        # Handle torch tensors (only if torch is already loaded -- a torch.Tensor
+        # cannot exist otherwise, so this never imports torch)
+        _torch = _torch_module()
+        if _torch is not None and isinstance(indices, _torch.Tensor):
             return indices.cpu().tolist()
 
         # Handle numpy arrays
@@ -58,7 +73,7 @@ class BatchMixin:
 
     def get_batch(
         self, indices: Union[List[int], range, slice, "torch.Tensor", np.ndarray]
-    ) -> "torch.Tensor":
+    ) -> "Union[torch.Tensor, np.ndarray]":
         """
         Decode a batch of frames at specified indices.
 
@@ -71,7 +86,9 @@ class BatchMixin:
                 - numpy.ndarray of indices
 
         Returns:
-            torch.Tensor of shape [B, H, W, C] where B = len(indices)
+            A stacked batch of shape [B, H, W, C]. For the PyTorch backend this
+            is a torch.Tensor; for the NumPy backend it is a numpy.ndarray
+            (built torch-free).
 
         Raises:
             IndexError: If any index is out of bounds
@@ -83,9 +100,14 @@ class BatchMixin:
         """
         # Convert to list
         indices_list = self._to_index_list(indices)
+        numpy_backend = self._is_numpy_backend()
 
         if not indices_list:
-            # Return empty tensor with correct shape
+            # Return empty batch with correct shape
+            if numpy_backend:
+                return np.empty((0, self.height, self.width, 3), dtype=np.uint8)
+            import torch
+
             return torch.empty(0, self.height, self.width, 3, dtype=torch.uint8)
 
         # Normalize negative indices
@@ -101,12 +123,19 @@ class BatchMixin:
             if not (0 <= idx < frame_count):
                 raise IndexError(f"Frame index {idx} out of bounds [0, {frame_count})")
 
-        # Call C++ decode_batch method
+        if numpy_backend:
+            # Torch-free batch: decode each frame individually and stack with
+            # numpy. This trades the C++ seek-minimization of decode_batch (which
+            # returns a torch::Tensor) for a fully torch-free path.
+            frames = [self.frame_at(int(idx)) for idx in normalized]
+            return np.stack(frames, axis=0)
+
+        # Call C++ decode_batch method (returns torch.Tensor)
         return self.decode_batch(normalized)
 
     def get_batch_range(
         self, start: int = 0, end: int = None, step: int = 1
-    ) -> "torch.Tensor":
+    ) -> "Union[torch.Tensor, np.ndarray]":
         """
         Decode a range of frames.
 
@@ -116,7 +145,7 @@ class BatchMixin:
             step: Step size (default: 1)
 
         Returns:
-            torch.Tensor of shape [B, H, W, C]
+            Batch of shape [B, H, W, C] (torch.Tensor or numpy.ndarray by backend).
 
         Examples:
             >>> vr = VideoReader("video.mp4")
@@ -139,7 +168,7 @@ class BatchMixin:
 
         Returns:
             - Single frame (torch.Tensor or numpy.ndarray based on backend)
-            - Batch of frames (torch.Tensor) for slice/list access
+            - Batch of frames (torch.Tensor or numpy.ndarray) for slice/list access
 
         Examples:
             >>> vr = VideoReader("video.mp4")
@@ -153,7 +182,11 @@ class BatchMixin:
             return super().__getitem__(key)
 
         # Slice or list - use batch decoding
-        if isinstance(key, (slice, list, tuple, range, torch.Tensor, np.ndarray)):
+        batch_types = [slice, list, tuple, range, np.ndarray]
+        _torch = _torch_module()
+        if _torch is not None:
+            batch_types.append(_torch.Tensor)
+        if isinstance(key, tuple(batch_types)):
             return self.get_batch(key)
 
         raise TypeError(f"Unsupported index type: {type(key)}")

--- a/src/Nelux/backends/Decoder.cpp
+++ b/src/Nelux/backends/Decoder.cpp
@@ -1089,6 +1089,77 @@ torch::Tensor Decoder::decodeNextFrameTensorSync(double* frame_timestamp)
     }
 }
 
+std::unique_ptr<uint8_t[]> Decoder::decodeNextFrameBufferSync(double* frame_timestamp)
+{
+    // Torch-free single-threaded decode used by the NumPy backend. Mirrors the
+    // worker-count==0 fallback of decodeNextFrameTensorSync but writes the
+    // converted RGB into a pooled raw buffer instead of a torch::Tensor, so no
+    // torch/c10 symbol is referenced on this path.
+    if (syncDrained_)
+        return nullptr;
+
+    AVFrame* f = syncFrame_.get();
+    while (true)
+    {
+        while (!syncEofReached_)
+        {
+            int rret = av_read_frame(formatCtx.get(), pkt.get());
+            if (rret < 0)
+            {
+                syncEofReached_ = true;
+                break;
+            }
+            if (pkt->stream_index != videoStreamIndex)
+            {
+                av_packet_unref(pkt.get());
+                continue;
+            }
+            int sret = avcodec_send_packet(codecCtx.get(), pkt.get());
+            av_packet_unref(pkt.get());
+            if (sret == AVERROR(EAGAIN))
+                break;
+            if (sret < 0)
+            {
+                syncDrained_ = true;
+                return nullptr;
+            }
+            break;
+        }
+        if (syncEofReached_ && !syncFlushSent_)
+        {
+            avcodec_send_packet(codecCtx.get(), nullptr);
+            syncFlushSent_ = true;
+        }
+        int ret = avcodec_receive_frame(codecCtx.get(), f);
+        if (ret == 0)
+        {
+            if (frame_timestamp)
+                *frame_timestamp = getFrameTimestamp(f);
+            setLastMotionVectors(extractMotionVectors(f));
+            setLastFrameType(f);
+            const int elemSize = (force_8bit || properties.bitDepth <= 8) ? 1 : 2;
+            const size_t nbytes = static_cast<size_t>(properties.width) *
+                                  static_cast<size_t>(properties.height) * 3 *
+                                  static_cast<size_t>(elemSize);
+            std::unique_ptr<uint8_t[]> buf = acquireOutputBuffer(nbytes);
+            if (converter)
+                converter->convert(syncFrame_, buf.get());
+            av_frame_unref(f);
+            return buf;
+        }
+        if (ret == AVERROR_EOF)
+        {
+            syncDrained_ = true;
+            return nullptr;
+        }
+        if (ret != AVERROR(EAGAIN))
+        {
+            syncDrained_ = true;
+            return nullptr;
+        }
+    }
+}
+
 bool Decoder::seekFrame(int frameIndex)
 {
     NELUX_TRACE("Seeking to frame index: {}", frameIndex);

--- a/src/Nelux/python/VideoReader.cpp
+++ b/src/Nelux/python/VideoReader.cpp
@@ -99,7 +99,7 @@ VideoReader::VideoReader(const std::string& filePath, int numThreads, bool force
             tensor = torch::empty(
                 {properties.height, properties.width, 3},
                 torch::TensorOptions().dtype(torchDataType).device(torchDevice));
-            CHECK_TENSOR(*tensor);
+            CHECK_TENSOR((*tensor));
 
             NELUX_INFO("VideoReader initialized with HWC format, dtype={}",
                        torchDataType == torch::kUInt8 ? "UInt8" : "UInt16");

--- a/src/Nelux/python/VideoReader.cpp
+++ b/src/Nelux/python/VideoReader.cpp
@@ -61,8 +61,12 @@ VideoReader::VideoReader(const std::string& filePath, int numThreads, bool force
         // for hardware decode and silent fallback has historically masked
         // configuration mistakes (wrong device, missing codec support, etc.).
         // Set decode_accelerator='cpu' explicitly to opt into software decode.
+        // The NumPy backend always uses the torch-free synchronous buffer path
+        // (decodeNextFrameBufferSync), so force sync mode for NumPy+CPU
+        // regardless of prefetch (the async producer fills torch::Tensors).
         const bool syncMode =
-            !prefetch && decodeAccelerator == nelux::DecodeAccelerator::CPU;
+            decodeAccelerator == nelux::DecodeAccelerator::CPU &&
+            (!prefetch || backend == Backend::NumPy);
         decoder = nelux::createDecoder(
             filePath, numThreads, decodeAccelerator, cuda_device_index,
             resizeWidth_, resizeHeight_, syncMode);
@@ -80,18 +84,30 @@ VideoReader::VideoReader(const std::string& filePath, int numThreads, bool force
 
         properties = decoder->getVideoProperties();
 
-        // Always use HWC format with native dtype (uint8/int16):
-        // - No BCHW conversion
-        // - No floating point conversion
-        // - Native bit depth preserved
-        torch::Dtype torchDataType = findTypeFromBitDepth();
-        tensor = torch::empty(
-            {properties.height, properties.width, 3},
-            torch::TensorOptions().dtype(torchDataType).device(torchDevice));
-        CHECK_TENSOR(tensor);
-        
-        NELUX_INFO("VideoReader initialized with HWC format, dtype={}", 
-                   torchDataType == torch::kUInt8 ? "UInt8" : "UInt16");
+        // The shared torch::Tensor is only used by the PyTorch backend and the
+        // NVDEC path (in-place GPU write). Allocating it calls torch::empty (a
+        // torch_cpu symbol) which would break `import nelux` when PyTorch is
+        // absent, so the NumPy CPU path skips it entirely and stays torch-free.
+        if (backend == Backend::PyTorch ||
+            decodeAccelerator == nelux::DecodeAccelerator::NVDEC)
+        {
+            // Always use HWC format with native dtype (uint8/int16):
+            // - No BCHW conversion
+            // - No floating point conversion
+            // - Native bit depth preserved
+            torch::Dtype torchDataType = findTypeFromBitDepth();
+            tensor = torch::empty(
+                {properties.height, properties.width, 3},
+                torch::TensorOptions().dtype(torchDataType).device(torchDevice));
+            CHECK_TENSOR(tensor);
+
+            NELUX_INFO("VideoReader initialized with HWC format, dtype={}",
+                       torchDataType == torch::kUInt8 ? "UInt8" : "UInt16");
+        }
+        else
+        {
+            NELUX_INFO("VideoReader initialized (NumPy backend, torch-free CPU path)");
+        }
     }
     catch (const std::exception& ex)
     {
@@ -218,11 +234,43 @@ void VideoReader::setRangeByTimestamps(double startTime, double endTime)
     NELUX_INFO("Timestamp range set: start_time={}, end_time={}", start_time, end_time);
 }
 
-torch::Tensor VideoReader::decodeFrame()
+py::object VideoReader::decodeFrame()
 {
     NELUX_TRACE("decodeFrame() called");
-    py::gil_scoped_release release; // Release GIL before calling decoder
 
+    // ---- NumPy backend, CPU decode: fully torch-free raw-buffer path. ----
+    // Decodes into a pooled uint8 buffer and wraps it as a numpy array without
+    // ever constructing a torch::Tensor, so no torch/c10 symbol is touched.
+    if (backend == Backend::NumPy &&
+        decodeAccelerator == nelux::DecodeAccelerator::CPU)
+    {
+        double frame_timestamp = 0.0;
+        std::unique_ptr<uint8_t[]> buf;
+        {
+            py::gil_scoped_release release;
+            try
+            {
+                buf = decoder->decodeNextFrameBufferSync(&frame_timestamp);
+            }
+            catch (const std::exception& ex)
+            {
+                NELUX_ERROR("decodeFrame(): decoder failed: {}", ex.what());
+                throw;
+            }
+        }
+        if (!buf)
+        {
+            NELUX_WARN("Decoding failed or no more frames available");
+            return py::none();
+        }
+        current_timestamp = frame_timestamp;
+        currentIndex++;
+        NELUX_TRACE("Frame decoded (numpy) index={}, timestamp={}", currentIndex - 1,
+                    current_timestamp);
+        return bufferToNumpy(std::move(buf));
+    }
+
+    // ---- PyTorch backend / NVDEC: torch::Tensor path. ----
     double frame_timestamp = 0.0;
     bool success = false;
     torch::Tensor outTensor;  // populated by zero-copy CPU path
@@ -232,33 +280,36 @@ torch::Tensor VideoReader::decodeFrame()
     // masked configuration errors and silently switched output devices/tensor
     // layouts under the caller's feet. Use decode_accelerator='cpu' to opt in
     // to software decode explicitly.
-    try
     {
-        if (decodeAccelerator == nelux::DecodeAccelerator::CPU)
+        py::gil_scoped_release release; // Release GIL before calling decoder
+        try
         {
-            outTensor = prefetch
-                            ? decoder->decodeNextFrameTensor(&frame_timestamp)
-                            : decoder->decodeNextFrameTensorSync(&frame_timestamp);
-            success = outTensor.defined();
+            if (decodeAccelerator == nelux::DecodeAccelerator::CPU)
+            {
+                outTensor = prefetch
+                                ? decoder->decodeNextFrameTensor(&frame_timestamp)
+                                : decoder->decodeNextFrameTensorSync(&frame_timestamp);
+                success = outTensor.defined();
+            }
+            else
+            {
+                // NVDEC / hardware path: in-place write into shared CUDA tensor.
+                success = decoder->decodeNextFrame(tensor.data_ptr(), &frame_timestamp);
+            }
         }
-        else
+        catch (const std::exception& ex)
         {
-            // NVDEC / hardware path: in-place write into shared CUDA tensor.
-            success = decoder->decodeNextFrame(tensor.data_ptr(), &frame_timestamp);
+            NELUX_ERROR("decodeFrame(): decoder failed: {}. "
+                        "Set decode_accelerator='cpu' to use software decode.",
+                        ex.what());
+            throw;
         }
     }
-    catch (const std::exception& ex)
-    {
-        NELUX_ERROR("decodeFrame(): decoder failed: {}. "
-                    "Set decode_accelerator='cpu' to use software decode.",
-                    ex.what());
-        throw;
-    }
-    
+
     if (!success)
     {
         NELUX_WARN("Decoding failed or no more frames available");
-        return torch::Tensor(); // Return an empty tensor if decoding failed
+        return py::none();
     }
 
     // Update current timestamp
@@ -269,22 +320,52 @@ torch::Tensor VideoReader::decodeFrame()
                 current_timestamp);
     // CPU path returns a per-frame tensor (zero-copy from decoder pool).
     // GPU path still returns the shared `tensor` member.
-    return outTensor.defined() ? outTensor : tensor;
+    return tensorToOutput(outTensor.defined() ? outTensor : tensor);
+}
+
+py::object VideoReader::emptyFrame() const
+{
+    if (backend == Backend::NumPy)
+        return py::array(py::dtype::of<uint8_t>(),
+                         {static_cast<py::ssize_t>(0),
+                          static_cast<py::ssize_t>(properties.width),
+                          static_cast<py::ssize_t>(3)});
+    return py::cast(torch::Tensor());
+}
+
+py::object VideoReader::bufferToNumpy(std::unique_ptr<uint8_t[]> buf) const
+{
+    const int elemSize = (force_8bit || properties.bitDepth <= 8) ? 1 : 2;
+    py::dtype dt =
+        (elemSize == 1) ? py::dtype::of<uint8_t>() : py::dtype::of<uint16_t>();
+    std::vector<py::ssize_t> shape = {static_cast<py::ssize_t>(properties.height),
+                                      static_cast<py::ssize_t>(properties.width),
+                                      static_cast<py::ssize_t>(3)};
+    std::vector<py::ssize_t> strides = {
+        static_cast<py::ssize_t>(properties.width) * 3 * elemSize,
+        static_cast<py::ssize_t>(3) * elemSize,
+        static_cast<py::ssize_t>(elemSize)};
+    // Hand the buffer to a capsule that delete[]s it when the array is GC'd.
+    // Each decoded frame owns a distinct buffer (acquireOutputBuffer), so this
+    // zero-copy view never aliases a later frame.
+    uint8_t* raw = buf.release();
+    py::capsule base(raw, [](void* p) { delete[] static_cast<uint8_t*>(p); });
+    return py::array(dt, shape, strides, raw, base);
 }
 
 py::object VideoReader::readFrame()
 {
     NELUX_TRACE("readFrame() called");
-    torch::Tensor frame = decodeFrame();
-    return tensorToOutput(frame);
+    py::object frame = decodeFrame();
+    return frame.is_none() ? emptyFrame() : frame;
 }
 
 py::tuple VideoReader::readFrameWithMotionVectors()
 {
-    torch::Tensor frame = decodeFrame();
-    if (!frame.defined() || frame.numel() == 0)
-        return py::make_tuple(tensorToOutput(frame), py::list());
-    return py::make_tuple(tensorToOutput(frame), getMotionVectors());
+    py::object frame = decodeFrame();
+    if (frame.is_none())
+        return py::make_tuple(emptyFrame(), py::list());
+    return py::make_tuple(frame, getMotionVectors());
 }
 
 py::tuple VideoReader::readMotionVectors()
@@ -583,11 +664,11 @@ py::object VideoReader::operator[](py::object key)
         // forward jump).
         if (diff_frames >= 0 && diff_sec <= smart_seek_threshold_sec)
         {
-            torch::Tensor f;
+            py::object f = py::none();
             for (long long i = 0; i <= diff_frames; ++i)
             {
                 f = decodeFrame();
-                if (!f.defined() || f.numel() == 0)
+                if (f.is_none())
                 {
                     throw std::runtime_error(
                         "Failed to decode frame near index " + std::to_string(req) +
@@ -595,7 +676,7 @@ py::object VideoReader::operator[](py::object key)
                         ")");
                 }
             }
-            return tensorToOutput(f);
+            return f;
         }
 
         // Fallback to random decoder
@@ -624,7 +705,7 @@ py::object VideoReader::operator[](py::object key)
                     ? static_cast<int>(properties.fps * smart_seek_threshold_sec) + 8
                     : 150;
 
-            torch::Tensor f;
+            py::object f = py::none();
             for (int i = 0; i < cap; ++i)
             {
                 // If we are already close enough, we might need a frame?
@@ -637,11 +718,11 @@ py::object VideoReader::operator[](py::object key)
 
                 // For now, let's keep it simple: if we are close, just decode.
                 f = decodeFrame();
-                if (!f.defined() || f.numel() == 0)
+                if (f.is_none())
                     break;
 
                 if (current_timestamp + 1e-9 >= ts - half)
-                    return tensorToOutput(f);
+                    return f;
             }
             // If loop fails, fall back
         }
@@ -685,7 +766,7 @@ void VideoReader::ensureRandDecoder()
     }
 }
 
-torch::Tensor VideoReader::decodeFrameAt(double timestamp_seconds)
+py::object VideoReader::decodeFrameAt(double timestamp_seconds)
 {
     ensureRandDecoder();
     if (!rand_decoder)
@@ -706,11 +787,48 @@ torch::Tensor VideoReader::decodeFrameAt(double timestamp_seconds)
         }
     }
 
-    // 2. Decode forward until we reach the requested timestamp
-    torch::Tensor out_frame;
-    double hit_ts = -1.0;
     const double half = 0.5 * ((properties.fps > 0) ? 1.0 / properties.fps : 0.0);
     int safety = 0, cap = static_cast<int>(properties.fps * 3) + 16;
+
+    // ---- NumPy backend, CPU: torch-free raw-buffer random access. ----
+    // decodeNextFrame(void*) writes converted RGB into a caller buffer, so no
+    // torch::Tensor is needed for the random-access path either.
+    if (backend == Backend::NumPy &&
+        decodeAccelerator == nelux::DecodeAccelerator::CPU)
+    {
+        const int elemSize = (force_8bit || properties.bitDepth <= 8) ? 1 : 2;
+        const size_t nbytes = static_cast<size_t>(properties.width) *
+                              static_cast<size_t>(properties.height) * 3 *
+                              static_cast<size_t>(elemSize);
+        std::unique_ptr<uint8_t[]> buf(new uint8_t[nbytes]);
+        while (true)
+        {
+            double ts = 0.0;
+            bool ok;
+            {
+                py::gil_scoped_release release;
+                ok = rand_decoder->decodeNextFrame(buf.get(), &ts);
+            }
+            if (!ok)
+                break;
+            if (ts + 1e-9 >= timestamp_seconds - half)
+            {
+                NELUX_DEBUG("decodeFrameAt(numpy): hit ts={}", ts);
+                return bufferToNumpy(std::move(buf));
+            }
+            if (++safety > cap)
+            {
+                NELUX_WARN("decodeFrameAt(): safety cap hit while advancing to ts={}",
+                           timestamp_seconds);
+                break;
+            }
+        }
+        throw std::runtime_error("Failed to decode frame at requested timestamp");
+    }
+
+    // ---- PyTorch backend / NVDEC: torch::Tensor path. ----
+    torch::Tensor out_frame;
+    double hit_ts = -1.0;
 
     // Allocate buffer once outside the loop
     torch::Tensor buf = makeLikeOutputTensor();
@@ -746,10 +864,10 @@ torch::Tensor VideoReader::decodeFrameAt(double timestamp_seconds)
         throw std::runtime_error("Failed to decode frame at requested timestamp");
 
     NELUX_DEBUG("decodeFrameAt(): hit ts={}", hit_ts);
-    return out_frame;
+    return tensorToOutput(out_frame);
 }
 
-torch::Tensor VideoReader::decodeFrameAt(int frame_index)
+py::object VideoReader::decodeFrameAt(int frame_index)
 {
     NELUX_TRACE("decodeFrameAt(index={}) using rand_decoder", frame_index);
 
@@ -762,14 +880,12 @@ torch::Tensor VideoReader::decodeFrameAt(int frame_index)
 
 py::object VideoReader::frameAt(double timestamp_seconds)
 {
-    torch::Tensor frame = decodeFrameAt(timestamp_seconds);
-    return tensorToOutput(frame);
+    return decodeFrameAt(timestamp_seconds);
 }
 
 py::object VideoReader::frameAt(int frame_index)
 {
-    torch::Tensor frame = decodeFrameAt(frame_index);
-    return tensorToOutput(frame);
+    return decodeFrameAt(frame_index);
 }
 
 bool VideoReader::seekToFrame(int frame_number)
@@ -811,7 +927,7 @@ VideoReader& VideoReader::iter()
     // Reset iterator state
     currentIndex = 0;
     current_timestamp = 0.0;
-    bufferedFrame = torch::Tensor(); // Clear any old buffered frame
+    bufferedFrame = py::object(); // Clear any old buffered frame
     hasBufferedFrame = false;
 
     if (start_time >= 0.0 && end_time > 0.0)
@@ -837,8 +953,7 @@ VideoReader& VideoReader::iter()
             // NVDEC seek-to-zero can skip early frames; reopen decoder to ensure start.
             decoder->reconfigure(filePath);
         }
-        else if (start_time <= 0.0 &&
-                 decodeAccelerator == nelux::DecodeAccelerator::CPU && !prefetch)
+        else if (start_time <= 0.0 && isCpuSyncPath())
         {
             // CPU sync path: seeking flushes a frame-threaded codec context and
             // trips an internal FFmpeg assertion (see the no-range branch). The
@@ -862,8 +977,8 @@ VideoReader& VideoReader::iter()
         while (true)
         {
             // Attempt to decode a frame
-            torch::Tensor f = decodeFrame();
-            if (!f.defined() || f.numel() == 0)
+            py::object f = decodeFrame();
+            if (f.is_none())
             {
                 // No more frames, or decode error
                 NELUX_WARN("Ran out of frames while discarding up to start_time={}",
@@ -902,7 +1017,7 @@ VideoReader& VideoReader::iter()
             currentIndex = 0;
             current_timestamp = 0.0;
         }
-        else if (decodeAccelerator == nelux::DecodeAccelerator::CPU && !prefetch)
+        else if (isCpuSyncPath())
         {
             // The CPU sync path uses a frame-threaded codec context; seeking it
             // (which flushes the decoder via avcodec_flush_buffers) is unsafe
@@ -919,8 +1034,8 @@ VideoReader& VideoReader::iter()
             current_timestamp = 0.0;
             for (int i = 0; i < start_frame; ++i)
             {
-                torch::Tensor f = decodeFrame();
-                if (!f.defined() || f.numel() == 0)
+                py::object f = decodeFrame();
+                if (f.is_none())
                 {
                     NELUX_WARN("Ran out of frames while discarding up to "
                                "start_frame={} (stopped at index {})",
@@ -954,7 +1069,7 @@ VideoReader& VideoReader::iter()
         // trips an internal assertion. Since iter() at this branch is only
         // hit when no range is set and we have not decoded anything yet,
         // skipping the seek-to-zero is correct.
-        if (!(decodeAccelerator == nelux::DecodeAccelerator::CPU && !prefetch))
+        if (!isCpuSyncPath())
         {
             bool success = seek(0.0);
             if (!success)
@@ -981,7 +1096,7 @@ py::object VideoReader::next()
     }
 
     // If we have a buffered frame from the discard loop, consume it first.
-    torch::Tensor frame;
+    py::object frame;
     if (hasBufferedFrame)
     {
         frame = bufferedFrame;
@@ -992,7 +1107,7 @@ py::object VideoReader::next()
     {
         // Otherwise decode the next frame
         frame = decodeFrame();
-        if (!frame.defined() || frame.numel() == 0)
+        if (frame.is_none())
         {
             NELUX_INFO("No more frames available (decode returned empty).");
             throw py::stop_iteration();
@@ -1032,7 +1147,7 @@ py::object VideoReader::next()
     {
         rangeFramesEmitted_++;
     }
-    return tensorToOutput(frame);
+    return frame;
 }
 
 void VideoReader::enter()

--- a/src/Nelux/python/VideoReader.cpp
+++ b/src/Nelux/python/VideoReader.cpp
@@ -99,7 +99,7 @@ VideoReader::VideoReader(const std::string& filePath, int numThreads, bool force
             tensor = torch::empty(
                 {properties.height, properties.width, 3},
                 torch::TensorOptions().dtype(torchDataType).device(torchDevice));
-            CHECK_TENSOR(tensor);
+            CHECK_TENSOR(*tensor);
 
             NELUX_INFO("VideoReader initialized with HWC format, dtype={}",
                        torchDataType == torch::kUInt8 ? "UInt8" : "UInt16");
@@ -294,7 +294,7 @@ py::object VideoReader::decodeFrame()
             else
             {
                 // NVDEC / hardware path: in-place write into shared CUDA tensor.
-                success = decoder->decodeNextFrame(tensor.data_ptr(), &frame_timestamp);
+                success = decoder->decodeNextFrame(tensor->data_ptr(), &frame_timestamp);
             }
         }
         catch (const std::exception& ex)
@@ -320,7 +320,7 @@ py::object VideoReader::decodeFrame()
                 current_timestamp);
     // CPU path returns a per-frame tensor (zero-copy from decoder pool).
     // GPU path still returns the shared `tensor` member.
-    return tensorToOutput(outTensor.defined() ? outTensor : tensor);
+    return tensorToOutput(outTensor.defined() ? outTensor : *tensor);
 }
 
 py::object VideoReader::emptyFrame() const
@@ -535,7 +535,7 @@ torch::Tensor VideoReader::makeLikeOutputTensor() const
 {
     return torch::empty(
         {properties.height, properties.width, 3},
-        torch::TensorOptions().dtype(tensor.dtype()).device(tensor.device()));
+        torch::TensorOptions().dtype(tensor->dtype()).device(tensor->device()));
 }
 
 bool VideoReader::seek(double timestamp)
@@ -1345,21 +1345,26 @@ void VideoReader::reconfigure(const std::string& newFilePath)
     start_time = -1.0;
     end_time = -1.0;
     
-    // Reallocate tensor if dimensions changed (always use BCHW format)
-    torch::Device torchDevice = tensor.device();
-    torch::Dtype torchDataType = findMLTypeFromBitDepth();
-    
-    if (tensor.size(2) != properties.height || 
-        tensor.size(3) != properties.width ||
-        tensor.dtype() != torchDataType)
+    // Reallocate tensor if dimensions changed (always use BCHW format). Only the
+    // PyTorch/NVDEC backends allocate the shared tensor; the NumPy CPU path
+    // leaves it disengaged (torch-free), so skip this entirely there.
+    if (tensor.has_value())
     {
-        tensor = torch::empty(
-            {1, 3, properties.height, properties.width},
-            torch::TensorOptions().dtype(torchDataType).device(torchDevice));
-        NELUX_DEBUG("Reallocated tensor for new dimensions: {}x{} (BCHW)", 
-                    properties.width, properties.height);
+        torch::Device torchDevice = tensor->device();
+        torch::Dtype torchDataType = findMLTypeFromBitDepth();
+
+        if (tensor->size(2) != properties.height ||
+            tensor->size(3) != properties.width ||
+            tensor->dtype() != torchDataType)
+        {
+            tensor = torch::empty(
+                {1, 3, properties.height, properties.width},
+                torch::TensorOptions().dtype(torchDataType).device(torchDevice));
+            NELUX_DEBUG("Reallocated tensor for new dimensions: {}x{} (BCHW)",
+                        properties.width, properties.height);
+        }
     }
-    
+
     NELUX_INFO("VideoReader reconfigured successfully for: {}", newFilePath);
 }
 


### PR DESCRIPTION
## Summary

`import nelux` no longer forces `import torch`. PyTorch is imported **only** when the `pytorch`/`nvdec` backend is used. The `backend="numpy"` decode path now runs with **PyTorch not installed at all** (Windows).

Verified in a torch-less venv (`.venv_notorch`, numpy only):
- `import nelux` succeeds; `torch` never enters `sys.modules`
- `read_frame` / iteration / sequential `vr[i]` return `numpy.ndarray`
- `backend="pytorch"` raises a clear `ImportError`

Torch-present venv unchanged: numpy stays torch-free even with torch installed; pytorch returns `torch.Tensor`; numpy/pytorch frames are byte-identical. Test suite: **176 passed, 16 skipped, 3 xfailed, 0 failed** (CPU build).

## How

- **Python** (`nelux/__init__.py`, `nelux/batch.py`): removed the forced-import guard; locate `torch/lib` via `find_spec` (no import) for the DLL search path; lazy `_ensure_torch()` + deferred ABI check, invoked only for pytorch/nvdec.
- **C++**: torch-free numpy decode — `Decoder::decodeNextFrameBufferSync` (raw `uint8_t[]`, single-threaded) → `VideoReader::bufferToNumpy` (pybind11-only, zero-copy). `decodeFrame`/`decodeFrameAt` now return `py::object`; the shared output tensor is held in `std::optional<torch::Tensor>` and engaged only for pytorch/nvdec.
- **Build/CI**: `/DELAYLOAD` `torch_cpu`/`torch_python`/`torch`. `c10.dll` **cannot** be delay-loaded (data-symbol import → `LNK1194`) so it is **bundled into the wheel** (1 MB, self-contained). CI delvewheel exclude updated accordingly.

## Two non-obvious traps

1. `c10.dll` = data-symbol dependency → undelayable → must ship it.
2. `at::Tensor`'s **default constructor** is itself an exported `torch_cpu` symbol, so a bare `torch::Tensor tensor;` member fired a thunk on every reader ctor. Gating `torch::empty()` alone was not enough — the member had to become `std::optional`.

## Scope / caveats

- **Windows only.** Linux/macOS have no delay-load equivalent (lazy binding defers symbol resolution, not library load), so torch stays a load-time dep there. Full decoupling there needs a torch-free-core / torch-addon module split.
- **c10.dll bundling** couples the wheel to that c10 build — worth a review given prior c10 double-vendor history. ABI-tagged wheels keep it matched.
- **Pre-existing (not introduced here):** `frame_at()` / large-jump `vr[i]` hangs (secondary/rand decoder) for **both** backends — already skipped in `test_backend.py` with that reason. numpy `get_batch` inherits it (loops `frame_at`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)