### PR TITLE
fix: stop frame_at() hang (random-access decoder ran async-fanout, consumer read wrong queue)

### DIFF
--- a/src/Nelux/python/VideoReader.cpp
+++ b/src/Nelux/python/VideoReader.cpp
@@ -678,9 +678,15 @@ void VideoReader::ensureRandDecoder()
         // No silent NVDEC->CPU fallback for the random-access decoder either.
         // A failure here surfaces as a hard error consistent with the main
         // decoder path; use decode_accelerator='cpu' for software decode.
+        //
+        // Force sync mode. Random access decodes one frame at a time via
+        // decodeNextFrame(void*), which drains convertedQueue/frameQueue. The
+        // async fanout producer instead routes every frame to the convert-worker
+        // map (syncConvertOutMap_, only decodeNextFrameTensor reads it), so those
+        // queues never fill and frame_at() deadlocks. Sync mode disables fanout.
         rand_decoder = nelux::createDecoder(
             filePath, numThreads, decodeAccelerator, cudaDeviceIndex,
-            resizeWidth_, resizeHeight_);
+            resizeWidth_, resizeHeight_, /*syncMode=*/true);
         rand_decoder->setForce8Bit(force_8bit);
     }
 }

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -127,7 +127,6 @@ def test_numpy_backend_frames_do_not_alias_memory():
     print("✓ NumPy backend frames use independent memory")
 
 
-@pytest.mark.skip(reason="frame_at secondary decoder hangs in this environment")
 def test_numpy_backend_frame_at():
     """Test that frame_at with numpy backend returns numpy.ndarray."""
     vr = VideoReader(VIDEO_PATH, backend="numpy")
@@ -147,7 +146,6 @@ def test_numpy_backend_frame_at():
     print(f"✓ NumPy backend frame_at: returns numpy.ndarray")
 
 
-@pytest.mark.skip(reason="integer/timestamp getitem uses the hanging frame_at path")
 def test_numpy_backend_getitem():
     """Test that __getitem__ with numpy backend returns numpy.ndarray."""
     vr = VideoReader(VIDEO_PATH, backend="numpy")

--- a/tests/test_batch_support.py
+++ b/tests/test_batch_support.py
@@ -175,7 +175,6 @@ class TestBatchEdgeCases:
 class TestBatchVsSequential:
     """Test that batch results match sequential frame_at calls."""
 
-    @pytest.mark.skip(reason="frame_at secondary decoder hangs in this environment")
     def test_consistency_with_frame_at(self):
         """Verify batch decode matches sequential frame_at."""
         vr = VideoReader(VIDEO_PATH)


### PR DESCRIPTION
## Problem

`frame_at()`, large-jump `__getitem__`, and numpy `get_batch` deadlock on any video longer than ~32 frames.

## Root cause

These paths route through the lazily-created `rand_decoder` (`VideoReader::decodeFrameAt`). `ensureRandDecoder` built it via `createDecoder(...)` **without** the `syncMode` argument, so it ran async with convert-worker fanout enabled (the default, `NELUX_ASYNC_FANOUT`).

In fanout mode `Decoder::decodingLoop` hands every decoded frame to the convert-worker output map (`syncConvertOutMap_`), which only `decodeNextFrameTensor` drains. But `decodeFrameAt` consumes via `decodeNextFrame(void*)`, which waits on `convertedQueue`/`frameQueue`. Those queues never fill; nothing drains the fanout map, so `in_flight` saturates at `syncMaxInFlight_` and the producer parks before EOF (`isFinished` never set), producing a permanent deadlock.

Videos with fewer than `syncMaxInFlight_` frames do not hang; they instead throw "Failed to decode frame at requested timestamp".

## Fix

Random access decodes one frame at a time and gains nothing from parallel convert fanout, so `ensureRandDecoder` now creates `rand_decoder` in **sync mode** (`/*syncMode=*/true`). That makes `decodingLoop`'s `fanout` false, so the producer fills the queue `decodeNextFrame(void*)` actually reads. NVDEC ignores `syncMode` (harmless); `rand_decoder`'s only consumers are the two `decodeNextFrame(void*)` calls in `decodeFrameAt`.

Un-skips the three `frame_at` tests that were masking the hang.

## Verification

- Repro: `frame_at(100)` on 14315-frame BigBuckBunny returns in 0.02s, no hang (previously deadlocked).
- Isolating proof: `NELUX_ASYNC_FANOUT=0` also resolves the hang, confirming fanout as the cause.
- `test_backend.py` + `test_batch_support.py` + `test_random_access_ui.py`: 36 passed, 1 skipped (unrelated, `cv2` not installed). No regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
