### PR TITLE
perf(encode): cap convert workers at 4 instead of 6

### DIFF
--- a/src/Nelux/python/VideoEncoder.cpp
+++ b/src/Nelux/python/VideoEncoder.cpp
@@ -564,7 +564,17 @@ void VideoEncoder::startEncodeWorkersIfNeeded()
     {
         unsigned hc = std::thread::hardware_concurrency();
         int k = (hc > 0) ? static_cast<int>(hc) / 2 : 4;
-        numConvertWorkers = std::clamp(k, 2, 6);
+        // Capped at 4, not 6. One swscale RGB->YUV costs ~1.4 ms at 720p and
+        // ~11 ms at 4K, so sustaining even the fastest encoders needs only ~2-3
+        // converters in flight; workers past that just take cores away from the
+        // encoder's own (barrier-synchronised) worker threads and cost pool RAM.
+        // Measured paired A/B, 6 -> 4 workers: 720p mpeg4 +2.0% (8/8 pairs),
+        // 720p x264 +0.6%, 1080p x264/mpeg4 +0.9%, 4K neutral. The encoded
+        // elementary stream is byte-identical either way (verified across
+        // x264/x265/mpeg4/ffv1/mjpeg/prores) — worker count only decides which
+        // thread runs a given frame's convert, and the submit thread restores
+        // sequence order.
+        numConvertWorkers = std::clamp(k, 2, 4);
     }
     // workers + 2 keeps every convert worker fed (one filling, one draining)
     // without over-buffering. At 4K each in-flight slot costs ~24.8 MB RGB +


### PR DESCRIPTION
## What

`VideoEncoder::startEncodeWorkersIfNeeded` sized the RGB->YUV convert pool at
`clamp(cores/2, 2, 6)`. This lowers the cap to 4.

## Why

Stage profiling of the encode pipeline (720p, env-gated timers) shows the frame
period is almost entirely the encoder itself, and that the convert pool is
already off the critical path:

| stage | mpeg4 | x264 veryfast |
|---|---:|---:|
| frame period | 0.642 ms | 1.240 ms |
| submit thread busy | 0.633 ms (98%) | 1.224 ms (99%) |
| of which `avcodec_send_frame` | 0.621 ms | 1.213 ms |
| mux | 0.010 ms | 0.007 ms |
| submit thread waiting | 0.001 ms | 0.001 ms |

One swscale RGB->YUV costs about 1.4 ms at 720p and 11 ms at 4K, so sustaining
even the fastest encoder needs only ~2-3 converters in flight. Workers past that
take cores away from the encoder's own barrier-synchronised worker threads.

## Measurements

Paired interleaved A/B: both arms run in one process, alternating A,B,A,B, so
clock and thermal drift hit both equally. The reported figure is the median of
the per-pair ratios, which is immune to between-run drift.

| workload | 6 -> 4 workers |
|---|---:|
| 720p mpeg4 | **+2.0%** (8/8 pairs positive, min +0.6%) |
| 720p x264 | +0.6% |
| 1080p x264 | +0.9% |
| 1080p mpeg4 | +0.9% |
| 4K x264 / mpeg4 | -0.7% / +0.3% (within noise) |

Against ffmpeg 8.0.1 at matched parameters (3000 encodes cycled from 300 in-RAM
RGB frames, interleaved arms, 5 reps), this moves the one codec that was behind:

| codec | before | after |
|---|---:|---:|
| 720p mpeg4 | 0.856x | **0.894x** |
| 720p x264 | 1.054x | 1.067x |
| 720p x265 | 1.113x | 1.108x |
| 720p h264_nvenc | 1.017x | 1.021x |
| 1080p x264 / mpeg4 / nvenc | | 1.15x / 1.084x / 1.019x |

Matching parameters matters here: nelux converts RGB->YUV with BT.709 above 576
lines while ffmpeg's implicit auto_scale uses BT.601, ffmpeg silently picks
yuv444p for rgb24 input unless `-pix_fmt` is given, and nelux emits High profile
where ffmpeg's h264_nvenc defaults to Main. Unmatched, that last one alone reads
as nelux being 5% slower on NVENC.

## Output equivalence

The encoded elementary stream is byte-identical either way. Worker count only
decides which thread converts a given frame; each converter is configured
identically and the submit thread restores sequence order. Verified across
x264, x265, mpeg4, ffv1, mjpeg and prores at 2, 4 and 6 workers.

Hashing a whole `.mkv` shows spurious differences because Matroska writes a
wall-clock `DateUTC` element, so two identical runs differ. The comparison must
be done on the elementary stream:
`ffmpeg -i f.mkv -c:v copy -f rawvideo -`.

## Side effect

In-flight depth is `workers + 2`, so it drops from 8 to 6 slots. At 4K that is
about 74 MB less pool memory.

## Tests

`test_software_encoders`, `test_async_encode_pipeline`, `test_encoder_lifecycle`:
83 passed, 2 xfailed, 1 xpassed.

`tests/test_nvenc.py` fails to collect on this machine, but that is pre-existing
and unrelated: it imports nelux before torch.