### PR TITLE
fix(decode): honour the stream's colour matrix in CPU batch decode

### DIFF
--- a/src/Nelux/BatchDecoder.cpp
+++ b/src/Nelux/BatchDecoder.cpp
@@ -180,6 +180,36 @@ void BatchDecoder::copyFrameToOutput(
             throw std::runtime_error("Failed to create SwsContext");
         }
 
+        // Propagate the frame's colour matrix / range. sws_getContext leaves the
+        // coefficients at SWS_CS_DEFAULT, which is ITU601, so without this every
+        // clip was converted with the BT.601 matrix regardless of its declared
+        // color_space -- a bt709 clip came out of the batch API mis-coloured by
+        // up to 40/255 while iterating the same reader was byte-exact against
+        // ffmpeg. Mirrors conversion/cpu/AutoToRGB.hpp so the batch and iterate
+        // paths cannot drift: UNSPECIFIED folds to BT.470BG (libswscale's own
+        // default, which is also what ffmpeg/torchcodec use for untagged clips),
+        // and the RGB destination is always full range.
+        AVColorSpace coeff_cs = frame->colorspace;
+        if (coeff_cs == AVCOL_SPC_UNSPECIFIED)
+            coeff_cs = AVCOL_SPC_BT470BG;
+        AVColorRange src_color_range = frame->color_range;
+        if (src_color_range == AVCOL_RANGE_UNSPECIFIED)
+            src_color_range = AVCOL_RANGE_MPEG;
+
+        int cs_ok = sws_setColorspaceDetails(
+            temp_sws, sws_getCoefficients(coeff_cs),
+            (src_color_range == AVCOL_RANGE_JPEG) ? 1 : 0,
+            sws_getCoefficients(AVCOL_SPC_BT709), 1, 0, 1 << 16, 1 << 16);
+        if (cs_ok < 0) {
+            sws_freeContext(temp_sws);
+            av_freep(&dst_data[0]);
+            throw std::runtime_error(
+                "BatchDecoder: Failed to configure color space details (error=" +
+                std::to_string(cs_ok) + ", colorspace=" +
+                std::to_string(static_cast<int>(frame->colorspace)) + ", range=" +
+                std::to_string(static_cast<int>(src_color_range)) + ")");
+        }
+
         sws_scale(temp_sws, frame->data, frame->linesize, 0, frame->height,
                  dst_data, linesize);
         sws_freeContext(temp_sws);

--- a/tests/test_batch_color_matrix.py
+++ b/tests/test_batch_color_matrix.py
@@ -1,0 +1,96 @@
+"""Colour-matrix regression tests for the CPU batch decode path.
+
+GitHub #58: `decode_batch` / `get_batch` / `get_batch_range` built their
+SwsContext without propagating the frame's declared colourspace, so every clip
+was converted YUV->RGB with swscale's SWS_CS_DEFAULT (== ITU601) coefficients.
+Iterating the same reader honoured the declared matrix, so one file decoded to
+two different images depending on which API was used -- off by up to 40/255 on a
+bt709 clip, with no error or warning.
+
+The reference is ffmpeg's own RGB output, which the iterate path is byte-exact
+against; the batch path must match it too.
+"""
+
+import os
+import subprocess
+
+import numpy as np
+import pytest
+import torch
+
+from nelux import VideoReader
+
+NFRAMES = 4
+
+
+def _have_ffmpeg():
+    try:
+        subprocess.run(["ffmpeg", "-version"], capture_output=True, check=True)
+        return True
+    except (OSError, subprocess.CalledProcessError):
+        return False
+
+
+def _bt709_clip():
+    """A clip declaring color_space=bt709, color_range=tv."""
+    p = os.path.join(os.path.dirname(__file__), "data", "test_1080p.mp4")
+    if not os.path.exists(p):
+        pytest.skip("tests/data/test_1080p.mp4 not present")
+    return p
+
+
+def _ffmpeg_rgb(path, nframes, extra_args=()):
+    """ffmpeg's own rgb24 conversion of the first nframes, as [N, H*W*3] uint8."""
+    out = subprocess.run(
+        ["ffmpeg", "-v", "error", "-i", path, "-vframes", str(nframes),
+         *extra_args, "-pix_fmt", "rgb24", "-f", "rawvideo", "pipe:1"],
+        capture_output=True, check=True).stdout
+    return torch.from_numpy(np.frombuffer(out, np.uint8).reshape(nframes, -1).copy())
+
+
+def _cpu_batch(path, nframes):
+    with VideoReader(path, force_8bit=True, decode_accelerator="cpu") as r:
+        return r.get_batch_range(0, nframes, 1)
+
+
+class TestBatchColourMatrix:
+
+    def test_batch_matches_ffmpeg_on_bt709_clip(self):
+        if not _have_ffmpeg():
+            pytest.skip("ffmpeg not on PATH")
+        path = _bt709_clip()
+        ref = _ffmpeg_rgb(path, NFRAMES)
+        got = _cpu_batch(path, NFRAMES).reshape(NFRAMES, -1)
+        # Byte-exact: the batch path runs the same swscale conversion as ffmpeg.
+        # With BT.601 coefficients this differed by up to 40/255 (mean 6.8).
+        assert torch.equal(got, ref)
+
+    def test_batch_matches_iterate_on_bt709_clip(self):
+        path = _bt709_clip()
+        with VideoReader(path, force_8bit=True, decode_accelerator="cpu") as r:
+            r.set_range(0, NFRAMES)
+            it = torch.stack([f for f in r])
+        assert torch.equal(_cpu_batch(path, NFRAMES), it)
+
+    def test_get_batch_matches_iterate_on_bt709_clip(self):
+        # get_batch and get_batch_range share copyFrameToOutput; cover both entry
+        # points so a future divergence in either is caught.
+        path = _bt709_clip()
+        with VideoReader(path, force_8bit=True, decode_accelerator="cpu") as r:
+            r.set_range(0, NFRAMES)
+            it = torch.stack([f for f in r])
+        with VideoReader(path, force_8bit=True, decode_accelerator="cpu") as r:
+            batch = r.get_batch(list(range(NFRAMES)))
+        assert torch.equal(batch, it)
+
+    def test_batch_is_not_bt601_on_bt709_clip(self):
+        # Direct guard against a regression to SWS_CS_DEFAULT: the buggy output
+        # was byte-identical to ffmpeg with BT.601 forced, which is what pinned
+        # the cause to the matrix rather than to range handling.
+        if not _have_ffmpeg():
+            pytest.skip("ffmpeg not on PATH")
+        path = _bt709_clip()
+        ref601 = _ffmpeg_rgb(
+            path, NFRAMES, ("-vf", "scale=in_color_matrix=bt601:out_range=pc"))
+        got = _cpu_batch(path, NFRAMES).reshape(NFRAMES, -1)
+        assert not torch.equal(got, ref601)


### PR DESCRIPTION
Fixes #58.

## Problem

On the CPU backend, `decode_batch` / `get_batch` / `get_batch_range` converted YUV→RGB with the **BT.601** matrix regardless of the stream's declared `color_space`. Iterating the same reader honoured the declared matrix. So one file decoded to two different images depending on which API was used — for a `bt709` clip the batch output was off by up to **40/255** (mean 6.8), with 73% of pixels differing from the iterate path. No error, no warning.

## Cause

`BatchDecoder::copyFrameToOutput` built its context with `sws_getContext` and never called `sws_setColorspaceDetails`:

```cpp
SwsContext* temp_sws = sws_getContext(
    frame->width, frame->height, static_cast<AVPixelFormat>(frame->format),
    config_.width, config_.height, AV_PIX_FMT_RGB24,
    SWS_BILINEAR, nullptr, nullptr, nullptr);
...
sws_scale(temp_sws, ...);
```

`frame->colorspace` and `frame->color_range` were never read, so the coefficients stayed at `SWS_CS_DEFAULT` — which is `SWS_CS_ITU601` (`swscale.h`: `#define SWS_CS_DEFAULT 5`, `SWS_CS_ITU601 5`). The buggy output was byte-identical to ffmpeg with `in_color_matrix=bt601` forced, which is what pinned the cause to the matrix rather than to range handling (a per-channel linear fit did not close the gap).

The iterate path gets this right in `conversion/cpu/AutoToRGB.hpp`, which passes `av_frame->colorspace` through `sws_getCoefficients` and calls `sws_setColorspaceDetails` — the same thing libavfilter's `vf_scale` does, which is why iterate is byte-exact against ffmpeg.

## Fix

Propagate the frame's matrix and range, mirroring `AutoToRGB.hpp` so the two paths cannot drift:

- `UNSPECIFIED` folds to `AVCOL_SPC_BT470BG` — libswscale's own default, and what ffmpeg/torchcodec use for untagged clips. Deliberately **not** a height-based fallback; the comment in `AutoToRGB.hpp` records that being a ~33 VMAF point gap on untagged HD.
- The RGB destination is always full range (`dstRange = 1`).

`color_range` was latently wrong too: swscale only auto-detects full range via `handle_jpeg()` on deprecated `yuvj*` formats, so a `pc`-tagged `yuv420p` clip got limited-range expansion on the batch path but not on iterate. The same change fixes it.

`nvdec` is unaffected — its batch path constructs a second decoder and reuses the NVDEC iterate pipeline, whose NV12→RGB CUDA kernel already selects per-colourspace matrices.

Pre-existing since 37d3387 (present in shipped releases), not a regression from any recent work.

## Verification

`tests/data/test_1080p.mp4` declares `color_space=bt709`, `color_range=tv`. Reference is ffmpeg's own rgb24 output.

Before:

```
cpu iterate  vs ffmpeg        max=  0 mean=0.000     <- byte-exact
cpu batch    vs ffmpeg        max= 40 mean=6.791     <- wrong
cpu batch    vs ffmpeg BT.601 max=  0 mean=0.000     <- byte-exact against forced BT.601
```

After:

```
cpu iterate   vs ffmpeg        max=  0 mean=0.000
cpu batch     vs ffmpeg        max=  0 mean=0.000    <- byte-exact
cpu get_batch vs ffmpeg        max=  0 mean=0.000
cpu batch     vs cpu iterate   max=  0 mean=0.000    <- the two APIs now agree
cpu batch     vs ffmpeg BT.601 max= 40 mean=6.791    <- no longer 601
nvdec batch   vs ffmpeg        max=  3 mean=0.591    <- unchanged NV12 delta
```

`tests/test_batch_color_matrix.py` (new) asserts byte-exactness against ffmpeg for both batch entry points, equality with the iterate path, and — as a direct regression guard — that the output is *not* byte-identical to forced BT.601.

```
tests/test_batch_color_matrix.py                        4 passed
+ batch / indexing / random-access / pixfmt / colour /
  color-format / reconfigure / aliasing / transcode /
  cuda-pipeline suites                                  77 passed, 1 skipped
```

Found while building the ComfyUI node pack, where the batch path had to be dropped entirely for correctness, costing ~1.9x on strided reads that start late in a file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)