### PR TITLE
fix(cuda): multi-arch device code + checked launches; perf(decode): batch scaler cache and frame threading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,19 +61,27 @@ option(NELUX_BUILD_PYTHON "Build Python bindings"     ON)
 option(NELUX_BUNDLE_FFMPEG_DLLS "Bundle FFmpeg runtime DLLs into Windows wheels" ON)
 
 # Host-side performance options
-# - AVX2: targets modern x86_64 CPUs; can be disabled for broader compatibility.
+# - AVX2: baked-in AVX2/FMA for Nelux's own host code. DEFAULT OFF, because it
+#   was measured to be worth nothing while costing real compatibility.
+#   A/B on an RTX 3090 box (h264 720p, 6 alternating process-level reps,
+#   AVX2 vs baseline ISA built from identical sources):
+#     streaming decode  ~3988 vs ~3993 fps   (no difference)
+#     decode_batch      ~2192 vs ~2173 fps   (no difference)
+#   That is expected: essentially all per-pixel work happens inside the
+#   prebuilt FFmpeg DLLs (libswscale/libavcodec already dispatch AVX2/AVX-512
+#   at runtime) or in CUDA kernels. Nelux's own ~17k lines are glue and do
+#   almost no vectorizable math, so /arch:AVX2 only adds a hard AVX2
+#   requirement — pre-Haswell Intel and pre-Excavator AMD get an illegal
+#   instruction. Turn ON only if profiling on your target shows a win.
 #   Auto-disabled on non-x86 architectures (e.g. Apple Silicon arm64).
 #   Applied to both CXX and CUDA host compilation.
 # - LTO: enables interprocedural optimization (IPO/LTO) in Release when supported.
 #   Applied to every Nelux target (NeluxLib, nelux, NeluxCuda).
+#   (MSVC PGO on top of this was also measured: no difference either, same
+#   reason as AVX2.)
 # - CUDA_FAST_MATH: passes --use_fast_math to nvcc; safe for the NV12<->RGB
 #   color-conversion kernels we ship.
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64|x86|i386|i686")
-  set(_NELUX_AVX2_DEFAULT ON)
-else()
-  set(_NELUX_AVX2_DEFAULT OFF)
-endif()
-option(NELUX_ENABLE_AVX2            "Enable AVX2/FMA for host code (x86 only)" ${_NELUX_AVX2_DEFAULT})
+option(NELUX_ENABLE_AVX2            "Enable AVX2/FMA for host code (x86 only; measured no-op, off by default)" OFF)
 option(NELUX_ENABLE_LTO             "Enable IPO/LTO for Release builds"        ON)
 option(NELUX_ENABLE_CUDA_FAST_MATH  "Pass --use_fast_math to nvcc"             ON)
 
@@ -166,14 +174,84 @@ if(NELUX_ENABLE_CUDA)
   include(CheckLanguage)
   check_language(CUDA)
   if(CMAKE_CUDA_COMPILER)
+    # Pick the architecture list BEFORE enable_language(CUDA).
+    #
+    # Under CMP0104, enable_language(CUDA) unconditionally defines
+    # CMAKE_CUDA_ARCHITECTURES from nvcc's single default architecture (75 for
+    # CUDA 13.2). Any `if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)` guard placed
+    # after that call is therefore dead code, and the build silently ships a
+    # single-architecture module: that arch's SASS plus its PTX. PTX only JITs
+    # *forward*, so every GPU older than the build arch fails every kernel
+    # launch with cudaErrorNoKernelImageForDevice — which used to surface as
+    # fully black decoded frames. (The launch-error checks in
+    # backends/cuda/Decoder.cpp and conversion/gpu/RGBToAutoGPU.hpp now turn
+    # that failure into an exception rather than silent corruption.)
+    #
+    # Running the guard here instead means an explicit
+    # -DCMAKE_CUDA_ARCHITECTURES=... on the command line is still honored.
+    # CUDAToolkit_VERSION is not available yet, so query nvcc directly.
+    #
+    # The CUDAARCHS environment variable is normally consumed by
+    # enable_language(CUDA); since the guard now runs first it has to be checked
+    # here, or `CUDAARCHS=90 pip install .` would be silently discarded and
+    # build the full list anyway.
+    if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES AND DEFINED ENV{CUDAARCHS})
+      set(CMAKE_CUDA_ARCHITECTURES "$ENV{CUDAARCHS}"
+          CACHE STRING "CUDA architectures to build device code for")
+      set(_nelux_archs_from_env TRUE)
+    endif()
+
+    if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+      execute_process(
+        COMMAND "${CMAKE_CUDA_COMPILER}" --version
+        OUTPUT_VARIABLE _nvcc_version_out
+        ERROR_QUIET
+      )
+      if(_nvcc_version_out MATCHES "release ([0-9]+)\\.([0-9]+)")
+        set(_nvcc_ver "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}")
+      else()
+        set(_nvcc_ver "12.0")
+        message(WARNING "Could not parse nvcc version; assuming CUDA ${_nvcc_ver} for architecture selection")
+      endif()
+
+      set(_nelux_cuda_archs "75;80;86;89;90")
+      if(_nvcc_ver VERSION_LESS 13.0)
+        # Pascal/Volta were removed in CUDA 13; only offer them on 11.x/12.x.
+        list(PREPEND _nelux_cuda_archs "60;70")
+      endif()
+      if(NOT _nvcc_ver VERSION_LESS 12.8)
+        # Blackwell (RTX 50-series / B100+). Needs CUDA 12.8 or newer.
+        list(APPEND _nelux_cuda_archs "100;120")
+      endif()
+
+      set(CMAKE_CUDA_ARCHITECTURES "${_nelux_cuda_archs}"
+          CACHE STRING "CUDA architectures to build device code for")
+      message(STATUS "CUDA architectures (nvcc ${_nvcc_ver}): ${CMAKE_CUDA_ARCHITECTURES}")
+    elseif(_nelux_archs_from_env)
+      message(STATUS "CUDA architectures (CUDAARCHS): ${CMAKE_CUDA_ARCHITECTURES}")
+    else()
+      # Either the user passed -DCMAKE_CUDA_ARCHITECTURES, or this is a build
+      # tree configured before the fix above existed, whose cache still holds
+      # the single default arch written by a previous enable_language(CUDA).
+      # The two are indistinguishable here, so warn rather than claim the value
+      # was chosen deliberately: a stale single-arch cache produces a wheel that
+      # throws cudaErrorNoKernelImageForDevice on every other GPU.
+      message(STATUS "CUDA architectures (from cache or -D): ${CMAKE_CUDA_ARCHITECTURES}")
+      list(LENGTH CMAKE_CUDA_ARCHITECTURES _nelux_arch_count)
+      if(_nelux_arch_count LESS 2)
+        message(WARNING
+          "CMAKE_CUDA_ARCHITECTURES is set to a single architecture "
+          "(${CMAKE_CUDA_ARCHITECTURES}). If you did not pass this yourself, "
+          "this build tree predates Nelux's multi-arch default; delete "
+          "CMakeCache.txt and reconfigure, or the build will only run on that "
+          "one GPU architecture.")
+      endif()
+    endif()
+
     enable_language(CUDA)
     find_package(CUDAToolkit REQUIRED)
     message(STATUS "CUDA enabled: ${CMAKE_CUDA_COMPILER}")
     message(STATUS "CUDA Toolkit: ${CUDAToolkit_VERSION}")
-    # Set CUDA architectures for common GPUs (can be overridden)
-    if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-      set(CMAKE_CUDA_ARCHITECTURES "60;70;75;80;86;89;90" CACHE STRING "CUDA architectures")
-    endif()
   else()
     message(FATAL_ERROR 
       "NELUX_ENABLE_CUDA is ON but no CUDA compiler found!\n"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -41,13 +41,13 @@
       }
     },
     {
-      "name": "x64-release-cpu-baseline",
-      "displayName": "x64 Release (CPU, baseline ISA)",
+      "name": "x64-release-cpu-avx2",
+      "displayName": "x64 Release (CPU, AVX2 opt-in)",
       "inherits": "windows-base",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
         "NELUX_ENABLE_CUDA": "OFF",
-        "NELUX_ENABLE_AVX2": "OFF"
+        "NELUX_ENABLE_AVX2": "ON"
       }
     },
     {

--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ VideoReader(
 - **Python**: 3.13+ (see `pyproject.toml` `requires-python`)
 - **PyTorch**: 2.13+ (`import torch` must precede `import nelux`; the matching CUDA wheel provides the CUDA runtime nelux's NVDEC path needs)
 - **CUDA**: 13.x (for NVDEC/NVENC builds). CPU-only builds drop this requirement.
+- **GPU**: compute capability 7.5+ (Turing, GTX 16xx / RTX 20xx and newer) for the published CUDA wheels. CUDA 13 dropped Pascal and Volta, so Maxwell/Pascal/Volta cards need a source build against CUDA 12.x (`CUDAARCHS=61 pip install .`) even though they have NVDEC silicon.
 - **OS**: Windows 10/11, Linux (manylinux_2_28+ / Ubuntu 22.04+), macOS 12+ (Apple Silicon, CPU only)
 
 ---

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -492,7 +492,7 @@ for frame in reader:
 - YUV444, YUV444P16
 
 **Requirements:**
-- NVIDIA GPU with NVDEC support
+- NVIDIA GPU with NVDEC support, compute capability 7.5+ (Turing or newer) for the published wheels. Pre-Turing cards with NVDEC (Maxwell/Pascal/Volta) need a source build against CUDA 12.x, since CUDA 13 no longer targets those architectures.
 - CUDA toolkit installed
 - NeLux wheel built with CUDA support (`nelux.__cuda_support__ == True`)
 

--- a/include/Nelux/BatchDecoder.hpp
+++ b/include/Nelux/BatchDecoder.hpp
@@ -38,6 +38,17 @@ public:
      */
     explicit BatchDecoder(const Config& config);
 
+    ~BatchDecoder();
+
+    // Owns raw SwsContext/av_image_alloc resources freed in the destructor, so
+    // the implicitly generated copy operations would double-free them (and two
+    // live copies would share one scratch buffer). Not needed -- the only
+    // instance lives in a unique_ptr.
+    BatchDecoder(const BatchDecoder&) = delete;
+    BatchDecoder& operator=(const BatchDecoder&) = delete;
+    BatchDecoder(BatchDecoder&&) = delete;
+    BatchDecoder& operator=(BatchDecoder&&) = delete;
+
     /**
      * @brief Decode a batch of frames at specified indices
      * 
@@ -70,6 +81,34 @@ private:
     // packets until it is re-seeked (which flushes its buffers), so decode_batch
     // must force a seek before the next target.
     bool decoderDrained_ = false;
+
+    // Cached RGB24 scaling context + scratch buffer for copyFrameToOutput.
+    // Building an SwsContext (scaling tables, SIMD init) and allocating the RGB
+    // buffer once per decoded frame dominated batch decode; both are reused and
+    // only rebuilt when the source frame geometry/format changes. Freed in dtor.
+    SwsContext* copySws_ = nullptr;
+    int copySwsSrcW_ = -1;
+    int copySwsSrcH_ = -1;
+    int copySwsSrcFmt_ = -1; // AVPixelFormat
+    // Colour matrix / range the cached context was configured for. Part of the
+    // key because the YUV->RGB coefficients are baked into the context by
+    // sws_setColorspaceDetails; a stream that changes its VUI mid-file (some
+    // H.264 encoders re-tag at an IDR) must not keep the stale matrix.
+    int copySwsSrcCs_ = -1;    // AVColorSpace
+    int copySwsSrcRange_ = -1; // AVColorRange (after UNSPECIFIED->MPEG folding)
+    // Destination geometry the cached context and the cached buffer were each
+    // built for. config_ is immutable for the life of a BatchDecoder today, but
+    // keying on it keeps the cache self-correcting if the output size ever
+    // changes under instance reuse. The two are tracked separately on purpose:
+    // an explicitly supplied sws_ctx skips the context rebuild but not the
+    // buffer realloc, so a single shared "dst" field could let a stale context
+    // scale into a differently sized buffer.
+    int copySwsDstW_ = -1;
+    int copySwsDstH_ = -1;
+    int copyDstW_ = -1;
+    int copyDstH_ = -1;
+    uint8_t* copyBuf_[4] = {nullptr, nullptr, nullptr, nullptr};
+    int copyBufLines_[4] = {0, 0, 0, 0};
 
     /**
      * @brief Seek to a specific frame index

--- a/include/Nelux/backends/Decoder.hpp
+++ b/include/Nelux/backends/Decoder.hpp
@@ -352,9 +352,10 @@ class Decoder
     std::unique_ptr<BatchDecoder> batch_decoder_;
     int64_t cached_frame_count_ = -1;
 
-    // Separate slice-only codec context for batch/seek work, so the main
-    // codecCtx can stay frame-threaded (faster sequential decode) without
-    // tripping flush asserts. Lazily allocated on first decode_batch call.
+    // Separate codec context for batch/seek work, so BatchDecoder's seeks and
+    // per-seek flushes never touch the streaming codecCtx mid-iteration. Also
+    // frame-threaded (see decode_batch); NELUX_BATCH_SLICE_ONLY=1 forces the
+    // older slice-only configuration. Lazily allocated on first decode_batch.
     std::unique_ptr<AVCodecContext, AVCodecContextDeleter> batchCodecCtx_;
 
     // Cached file path for reconfiguration

--- a/include/Nelux/conversion/gpu/RGBToAutoGPU.hpp
+++ b/include/Nelux/conversion/gpu/RGBToAutoGPU.hpp
@@ -203,11 +203,28 @@ public:
                 throw std::runtime_error("RGBToAutoGPUConverter: Unsupported format");
         }
         
+        // Kernel launches are asynchronous; configuration/binary failures
+        // (notably cudaErrorNoKernelImageForDevice when the build's -gencode
+        // list omits this GPU's architecture) surface only through the sticky
+        // per-thread error. Unchecked, the launch silently no-ops and the YUV
+        // surface is encoded as uninitialized garbage.
+        if (cudaError_t launchErr = cudaGetLastError(); launchErr != cudaSuccess) {
+            throw std::runtime_error(
+                std::string("RGBToAutoGPUConverter: conversion kernel launch failed: ") +
+                cudaGetErrorString(launchErr) +
+                (launchErr == cudaErrorNoKernelImageForDevice
+                     ? ". This build contains no CUDA binary for the current GPU "
+                       "architecture; rebuild with CMAKE_CUDA_ARCHITECTURES covering it."
+                     : ""));
+        }
+
         // Synchronize to ensure conversion is complete
-        if (stream) {
-            cudaStreamSynchronize(stream);
-        } else {
-            cudaDeviceSynchronize();
+        cudaError_t syncErr = stream ? cudaStreamSynchronize(stream)
+                                     : cudaDeviceSynchronize();
+        if (syncErr != cudaSuccess) {
+            throw std::runtime_error(
+                std::string("RGBToAutoGPUConverter: conversion kernel failed: ") +
+                cudaGetErrorString(syncErr));
         }
     }
     

--- a/src/Nelux/BatchDecoder.cpp
+++ b/src/Nelux/BatchDecoder.cpp
@@ -2,6 +2,7 @@
 #include "Logger.hpp"
 #include "error/CxException.hpp"
 #include <algorithm>
+#include <cstring>
 #include <set>
 #include <stdexcept>
 
@@ -14,10 +15,29 @@ namespace nelux {
 BatchDecoder::BatchDecoder(const Config& config)
     : config_(config)
 {
+    // copyFrameToOutput converts to RGB24 and memcpys config_.height * width*3
+    // bytes per position. A channels value other than 3 would make the output
+    // tensor smaller than what is written, i.e. a heap overflow rather than
+    // merely wrong pixels. Grayscale batch decode is rejected in VideoReader;
+    // this is the load-bearing check for anyone reaching Decoder::decode_batch
+    // directly.
+    if (config_.channels != 3)
+        throw std::runtime_error(
+            "BatchDecoder: only 3-channel (RGB24) output is supported, got " +
+            std::to_string(config_.channels) + " channels");
+
     NELUX_DEBUG("BatchDecoder created: {}x{}x{}, dtype={}, device={}",
                 config_.width, config_.height, config_.channels,
                 static_cast<int>(config_.dtype),
                 config_.device.str());
+}
+
+BatchDecoder::~BatchDecoder()
+{
+    if (copySws_)
+        sws_freeContext(copySws_);
+    if (copyBuf_[0])
+        av_freep(&copyBuf_[0]);
 }
 
 void BatchDecoder::seekToFrame(
@@ -142,94 +162,120 @@ void BatchDecoder::copyFrameToOutput(
     SwsContext* sws_ctx)
 {
     NELUX_TRACE("Copying frame to {} positions", positions.size());
-    
+
     // Handle dimension mismatch by scaling (can happen after reconfigure with different video sizes)
     bool needsScaling = (frame->width != config_.width || frame->height != config_.height);
     if (needsScaling) {
         NELUX_WARN("Frame dimension mismatch: frame={}x{}, config={}x{}. Will scale to config dimensions.",
                    frame->width, frame->height, config_.width, config_.height);
     }
-    
-    // Allocate buffer for OUTPUT dimensions (config_) - not frame dimensions
-    int linesize[4] = {0};
-    uint8_t* dst_data[4] = {nullptr};
-    
-    int ret = av_image_alloc(dst_data, linesize, config_.width, config_.height,
-                            AV_PIX_FMT_RGB24, 1);
-    if (ret < 0) {
-        throw std::runtime_error("Failed to allocate image buffer");
-    }
 
-    // Convert frame to RGB, scaling if necessary
-    // Source dimensions: frame->width, frame->height (actual frame size)
-    // Dest dimensions: config_.width, config_.height (expected output size)
-    if (sws_ctx) {
-        // Use provided context (assumes it matches dimensions - this is risky!)
-        // Better to create a new context that handles the scaling
-        sws_scale(sws_ctx, frame->data, frame->linesize, 0, frame->height,
-                 dst_data, linesize);
-    } else {
-        // Create context with proper source (frame) and dest (config) dimensions
-        SwsContext* temp_sws = sws_getContext(
+    // Convert to RGB24 at OUTPUT (config_) dimensions. The scaling context and
+    // the destination buffer are cached across frames — building an SwsContext
+    // and allocating the buffer per frame previously dominated batch decode.
+    // Rebuild only when the source geometry/format changes. An explicitly
+    // provided sws_ctx (unused by the current caller) still takes precedence.
+    const int srcFmt = static_cast<int>(frame->format);
+    const int srcCs = static_cast<int>(frame->colorspace);
+    AVColorRange srcRangeEnum = frame->color_range;
+    if (srcRangeEnum == AVCOL_RANGE_UNSPECIFIED)
+        srcRangeEnum = AVCOL_RANGE_MPEG;
+    const int srcRangeKey = static_cast<int>(srcRangeEnum);
+
+    if (!sws_ctx &&
+        (!copySws_ || copySwsSrcW_ != frame->width ||
+         copySwsSrcH_ != frame->height || copySwsSrcFmt_ != srcFmt ||
+         copySwsSrcCs_ != srcCs || copySwsSrcRange_ != srcRangeKey ||
+         copySwsDstW_ != config_.width || copySwsDstH_ != config_.height)) {
+        if (copySws_) {
+            sws_freeContext(copySws_);
+            copySws_ = nullptr;
+        }
+        // Keys are invalidated up front: if configuration below throws, the
+        // half-built context must not be reachable through a stale-key cache hit
+        // on a later call.
+        copySwsSrcW_ = copySwsSrcH_ = copySwsSrcFmt_ = -1;
+        copySwsSrcCs_ = copySwsSrcRange_ = -1;
+        copySwsDstW_ = copySwsDstH_ = -1;
+        copySws_ = sws_getContext(
             frame->width, frame->height, static_cast<AVPixelFormat>(frame->format),
             config_.width, config_.height, AV_PIX_FMT_RGB24,
             SWS_BILINEAR, nullptr, nullptr, nullptr);
-        
-        if (!temp_sws) {
-            av_freep(&dst_data[0]);
+        if (!copySws_)
             throw std::runtime_error("Failed to create SwsContext");
-        }
 
-        // Propagate the frame's colour matrix / range. sws_getContext leaves the
-        // coefficients at SWS_CS_DEFAULT, which is ITU601, so without this every
-        // clip was converted with the BT.601 matrix regardless of its declared
-        // color_space -- a bt709 clip came out of the batch API mis-coloured by
-        // up to 40/255 while iterating the same reader was byte-exact against
-        // ffmpeg. Mirrors conversion/cpu/AutoToRGB.hpp so the batch and iterate
-        // paths cannot drift: UNSPECIFIED folds to BT.470BG (libswscale's own
-        // default, which is also what ffmpeg/torchcodec use for untagged clips),
-        // and the RGB destination is always full range.
+        // Propagate the frame's colour matrix / range. Without this the context
+        // keeps swscale's SWS_CS_DEFAULT (== ITU601) coefficients, so a bt709
+        // clip came out of the batch API mis-coloured by up to 40/255 while the
+        // iterate path on the same reader was byte-exact against ffmpeg.
+        // Mirrors conversion/cpu/AutoToRGB.hpp so the two paths cannot drift:
+        // UNSPECIFIED folds to BT.470BG (libswscale's own default, which is what
+        // ffmpeg/torchcodec do for untagged clips), and the RGB destination is
+        // always full range.
         AVColorSpace coeff_cs = frame->colorspace;
         if (coeff_cs == AVCOL_SPC_UNSPECIFIED)
             coeff_cs = AVCOL_SPC_BT470BG;
-        AVColorRange src_color_range = frame->color_range;
-        if (src_color_range == AVCOL_RANGE_UNSPECIFIED)
-            src_color_range = AVCOL_RANGE_MPEG;
+        const int* srcCoeffs = sws_getCoefficients(coeff_cs);
+        const int* dstCoeffs = sws_getCoefficients(AVCOL_SPC_BT709);
+        const int srcRange = (srcRangeEnum == AVCOL_RANGE_JPEG) ? 1 : 0;
 
-        int cs_ok = sws_setColorspaceDetails(
-            temp_sws, sws_getCoefficients(coeff_cs),
-            (src_color_range == AVCOL_RANGE_JPEG) ? 1 : 0,
-            sws_getCoefficients(AVCOL_SPC_BT709), 1, 0, 1 << 16, 1 << 16);
-        if (cs_ok < 0) {
-            sws_freeContext(temp_sws);
-            av_freep(&dst_data[0]);
+        int ok = sws_setColorspaceDetails(copySws_, srcCoeffs, srcRange, dstCoeffs,
+                                          1, 0, 1 << 16, 1 << 16);
+        if (ok < 0)
             throw std::runtime_error(
                 "BatchDecoder: Failed to configure color space details (error=" +
-                std::to_string(cs_ok) + ", colorspace=" +
-                std::to_string(static_cast<int>(frame->colorspace)) + ", range=" +
-                std::to_string(static_cast<int>(src_color_range)) + ")");
-        }
+                std::to_string(ok) + ", colorspace=" + std::to_string(srcCs) +
+                ", range=" + std::to_string(srcRangeKey) + ")");
 
-        sws_scale(temp_sws, frame->data, frame->linesize, 0, frame->height,
-                 dst_data, linesize);
-        sws_freeContext(temp_sws);
+        copySwsSrcW_ = frame->width;
+        copySwsSrcH_ = frame->height;
+        copySwsSrcFmt_ = srcFmt;
+        copySwsSrcCs_ = srcCs;
+        copySwsSrcRange_ = srcRangeKey;
+        copySwsDstW_ = config_.width;
+        copySwsDstH_ = config_.height;
     }
 
-    // Copy to all requested positions in output tensor
-    auto output_acc = output.accessor<uint8_t, 4>();
-    
+    // Allocate the config_-sized RGB24 scratch once, reallocating if the output
+    // geometry ever changes, so copyBuf_ always matches the sws destination size
+    // and sws_scale can never write past it. av_image_alloc with align=1 yields
+    // a row stride equal to width*3 for RGB24; the strided branch below only
+    // exists so a future alignment change cannot silently corrupt output.
+    if (!copyBuf_[0] || copyDstW_ != config_.width || copyDstH_ != config_.height) {
+        if (copyBuf_[0])
+            av_freep(&copyBuf_[0]);
+        int ret = av_image_alloc(copyBuf_, copyBufLines_, config_.width,
+                                 config_.height, AV_PIX_FMT_RGB24, 1);
+        if (ret < 0)
+            throw std::runtime_error("Failed to allocate image buffer");
+        copyDstW_ = config_.width;
+        copyDstH_ = config_.height;
+    }
+
+    SwsContext* use_sws = sws_ctx ? sws_ctx : copySws_;
+    sws_scale(use_sws, frame->data, frame->linesize, 0, frame->height,
+              copyBuf_, copyBufLines_);
+
+    // Copy the contiguous RGB24 rows into each requested [H,W,3] slice of the
+    // output tensor. output is a freshly allocated, contiguous uint8 [N,H,W,3]
+    // tensor, so each position is a H*rowBytes contiguous block; a per-row
+    // memcpy replaces the previous per-element 4D-accessor assignment.
+    const int rowBytes = config_.width * 3;
+    const int srcStride = copyBufLines_[0];
+    const size_t frameBytes = static_cast<size_t>(config_.height) * rowBytes;
+    uint8_t* out_base = output.data_ptr<uint8_t>();
+
     for (size_t pos : positions) {
-        for (int h = 0; h < config_.height; h++) {
-            for (int w = 0; w < config_.width; w++) {
-                for (int c = 0; c < config_.channels; c++) {
-                    int src_idx = h * linesize[0] + w * 3 + c;
-                    output_acc[pos][h][w][c] = dst_data[0][src_idx];
-                }
-            }
+        uint8_t* dst = out_base + pos * frameBytes;
+        if (srcStride == rowBytes) {
+            std::memcpy(dst, copyBuf_[0], frameBytes);
+        } else {
+            for (int h = 0; h < config_.height; ++h)
+                std::memcpy(dst + static_cast<size_t>(h) * rowBytes,
+                            copyBuf_[0] + static_cast<size_t>(h) * srcStride,
+                            rowBytes);
         }
     }
-
-    av_freep(&dst_data[0]);
 }
 
 torch::Tensor BatchDecoder::decode_batch(

--- a/src/Nelux/backends/Decoder.cpp
+++ b/src/Nelux/backends/Decoder.cpp
@@ -578,8 +578,11 @@ void Decoder::initCodecContext()
     // Enable FRAME threading (the big win for h264/hevc -- 4-8x). Falls back
     // to SLICE if frame threads aren't supported by this codec. Mixing both
     // sometimes makes ffmpeg pick the slower one; prefer frame-only when
-    // available. avcodec_flush_buffers under FF_THREAD_FRAME is unsafe, so
-    // batch/seek work uses a separate slice-only context (see decode_batch).
+    // available. seek() flushes this frame-threaded context (avcodec_flush_buffers)
+    // once the producer thread is stopped; that is safe. The documented crash
+    // was flushing while the async producer still had frame-thread workers in
+    // flight (the async_lock assert) -- a concurrency issue, not flush itself.
+    // decode_batch() likewise stops the producer and uses frame threading too.
     int supported_types = 0;
     if (codec->capabilities & AV_CODEC_CAP_FRAME_THREADS)
         supported_types = FF_THREAD_FRAME;
@@ -1699,7 +1702,21 @@ void Decoder::reconfigure(const std::string& filePath)
     if (batch_decoder_)
     {
         batch_decoder_.reset();
-        cached_frame_count_ = -1;
+    }
+    // Unconditionally, not just when a batch decoder exists: get_frame_count()
+    // populates this cache on its own (nb_frames / demux pass / duration*fps)
+    // and is reachable without ever touching batch decode, so gating the reset
+    // on batch_decoder_ left the old file's frame count live after a
+    // reconfigure -- reporting the wrong length and letting out-of-range
+    // indices through decode_batch's bounds check.
+    cached_frame_count_ = -1;
+    // The batch codec context is bound to the old file's stream parameters;
+    // drop it so decode_batch() rebuilds it for the new file. Leaving it stale
+    // made decode_batch() after a reconfigure to a different stream decode with
+    // the previous file's parameters (wrong frames / decode errors).
+    if (batchCodecCtx_)
+    {
+        batchCodecCtx_.reset();
     }
 
     // Re-initialize with new file (reusing existing converter settings if compatible)
@@ -2198,9 +2215,9 @@ torch::Tensor Decoder::decode_batch(const std::vector<int64_t>& indices)
         NELUX_DEBUG("Batch decoder initialized");
     }
 
-    // Lazily build a slice-only codec context dedicated to batch work. The
-    // main codecCtx is frame-threaded for fast sequential decode; flushing a
-    // frame-threaded codec under seek (as BatchDecoder does) is unsafe.
+    // Lazily build a codec context dedicated to batch work, kept separate from
+    // the streaming codecCtx so BatchDecoder's seeks and flushes cannot disturb
+    // an in-progress iteration. Threading for it is chosen below.
     if (!batchCodecCtx_)
     {
         AVStream* stream = formatCtx->streams[videoStreamIndex];
@@ -2220,17 +2237,39 @@ torch::Tensor Decoder::decode_batch(const std::vector<int64_t>& indices)
         if (ctx->codec_id == AV_CODEC_ID_AV1)
             ctx->thread_count = 1;
 
-        // Slice-only -- safe under avcodec_flush_buffers after seek.
+        // Threading for the batch/seek path. Frame threading decodes the
+        // keyframe->target run 2-5x faster than slice-only (which barely
+        // parallelizes single-slice H.264). decode_batch runs synchronously on
+        // the calling thread and stops the streaming producer above, so nothing
+        // else drives this context while BatchDecoder seeks it: the per-seek
+        // avcodec_flush_buffers lands on a quiescent decoder. (The documented
+        // async_lock crash was the *async* producer flushing with frame-thread
+        // workers still in flight.) This does NOT make concurrent decode_batch
+        // calls on one reader safe -- those already race on formatCtx and
+        // batchCodecCtx_, frame threads or not; one reader per thread.
+        // Mirror the main context: frame-only when available (both
+        // slice+frame can make ffmpeg pick the slower path), else slice.
+        // Validated byte-exact vs slice-only across h264/hevc/prores/ffv1/
+        // mpeg2/mpeg4/vp9 and 8/10/12-bit, incl. backward/out-of-order/dup
+        // indices and repeated batches. NELUX_BATCH_SLICE_ONLY=1 forces the old
+        // slice-only context (e.g. to bound threads under many concurrent readers).
+        const char* sliceOnlyEnv = std::getenv("NELUX_BATCH_SLICE_ONLY");
+        const bool sliceOnly = sliceOnlyEnv && std::atoi(sliceOnlyEnv) != 0;
         int batch_thread_types = 0;
-        if (codec->capabilities & AV_CODEC_CAP_SLICE_THREADS)
-            batch_thread_types |= FF_THREAD_SLICE;
+        if (!sliceOnly && (codec->capabilities & AV_CODEC_CAP_FRAME_THREADS))
+            batch_thread_types = FF_THREAD_FRAME;
+        else if (codec->capabilities & AV_CODEC_CAP_SLICE_THREADS)
+            batch_thread_types = FF_THREAD_SLICE;
         ctx->thread_type = batch_thread_types;
         ctx->time_base = stream->time_base;
         ctx->strict_std_compliance = FF_COMPLIANCE_EXPERIMENTAL;
 
         FF_CHECK_MSG(avcodec_open2(ctx, codec, nullptr),
                      std::string("Failed to open batch codec context:"));
-        NELUX_DEBUG("Batch codec context allocated (slice-only)");
+        NELUX_DEBUG("Batch codec context allocated (thread_type={})",
+                    batch_thread_types == FF_THREAD_FRAME ? "frame"
+                    : batch_thread_types == FF_THREAD_SLICE ? "slice"
+                                                            : "none");
     }
 
     return batch_decoder_->decode_batch(

--- a/src/Nelux/backends/cuda/Decoder.cpp
+++ b/src/Nelux/backends/cuda/Decoder.cpp
@@ -857,6 +857,23 @@ void Decoder::transferAndConvertFrame(AVFrame* hwFrame, void* outputBuffer,
     }
     }
 
+    // Kernel launches are asynchronous and report configuration//binary errors
+    // (notably cudaErrorNoKernelImageForDevice when the build's -gencode list
+    // omits this GPU's architecture) only via the sticky per-thread error.
+    // Without this check the launch silently no-ops and every decoded frame
+    // comes back as a fully black image.
+    cudaError_t launchErr = cudaGetLastError();
+    if (launchErr != cudaSuccess)
+    {
+        throw CxException(
+            std::string("CUDA DECODER: color-conversion kernel launch failed: ") +
+            cudaGetErrorString(launchErr) +
+            (launchErr == cudaErrorNoKernelImageForDevice
+                 ? ". This build contains no CUDA binary for the current GPU "
+                   "architecture; rebuild with CMAKE_CUDA_ARCHITECTURES covering it."
+                 : ""));
+    }
+
     // Note: We don't synchronize here - the stream ordering ensures
     // the conversion completes before the buffer is used
 }

--- a/src/Nelux/backends/cuda/NV12ToRGB.cu
+++ b/src/Nelux/backends/cuda/NV12ToRGB.cu
@@ -972,13 +972,17 @@ void launchNv12ToRgb24(
     cudaStream_t stream)
 {
     SetMatYuv2Rgb(colorSpace, colorRange, stream);
-    
+
+    // Block geometry is measured-optimal on Ampere: a sweep of
+    // {32,64,128,256}x{1,2,4} at 720p/1080p/4K put (32,2) at or within noise of
+    // the best result everywhere (4K: 677 GB/s effective, ~72% of an RTX 3090's
+    // peak). Wider or taller blocks lose L2 locality on the shared UV row.
     dim3 blockDim(32, 2);
     dim3 gridDim(
         (nWidth + 63) / 64,
         (nHeight + 3) / 4
     );
-    
+
     Nv12ToRgb24Kernel<<<gridDim, blockDim, 0, stream>>>(
         pNv12, nNv12Pitch, pRgb, nRgbPitch, nWidth, nHeight, nHeight, 
         colorRange == ColorRange_Full


### PR DESCRIPTION
Three pieces of work that had accumulated uncommitted on `master`, reviewed by three adversarial reviewers before being split into commits.

## `fix(cuda)`: build device code for all supported architectures

The `if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)` guard sat *after* `enable_language(CUDA)`, which under CMP0104 has already defined the variable from nvcc's single default architecture (75 on CUDA 13.2). The guard was dead code, so every build shipped one architecture. PTX only JITs forward, so every older GPU failed every kernel launch with `cudaErrorNoKernelImageForDevice` — which surfaced as fully black decoded frames.

The selection now runs before `enable_language(CUDA)` and picks from the nvcc version: `75;80;86;89;90`, plus `60;70` on CUDA < 13, plus `100;120` on CUDA >= 12.8.

Kernel launches in the NVDEC decoder and the encoder-side RGB converter are now checked with `cudaGetLastError()`. Launches are asynchronous, so a binary/configuration failure was only visible in the sticky per-thread error — unchecked, the launch silently no-opped and frames came back black or as uninitialised garbage.

`NELUX_ENABLE_AVX2` also flips to OFF by default (same file). Measured A/B against baseline ISA: no difference on streaming decode (~3988 vs ~3993 fps) or `decode_batch` (~2192 vs ~2173 fps), because the per-pixel work is inside the prebuilt FFmpeg DLLs or in CUDA kernels. It only added a hard AVX2 requirement.

## `build`: turn the CPU preset into an AVX2 opt-in

`x64-release-cpu-baseline` → `x64-release-cpu-avx2`, since a preset that only turns AVX2 off is now identical to the default.

## `perf(decode)`: cache the batch scaler and frame-thread the batch context

`copyFrameToOutput` built a fresh `SwsContext` and RGB24 buffer per decoded frame and copied through a per-element 4D accessor. Both are now cached (rebuilt only when source geometry/format/matrix/range changes) and the copy is a per-row `memcpy`. The batch codec context also moves from slice-only to frame threading, which was the dominant cost on the keyframe-to-target run. `NELUX_BATCH_SLICE_ONLY=1` restores the old context.

3-8x on `decode_batch`, byte-exact against previous output across h264/hevc/prores/ffv1/mpeg2/mpeg4/vp9 at 8/10/12-bit, including backward, out-of-order and duplicate indices.

## Review findings fixed in this PR

Adversarial review of the above turned up defects that are fixed here:

- `reconfigure()` left `batchCodecCtx_` bound to the old file's stream parameters — wrong frames after reconfiguring to a different stream.
- `reconfigure()` reset `cached_frame_count_` only when a batch decoder existed, but `get_frame_count()` populates that cache independently. The old file's frame count survived a reconfigure, misreporting length and letting out-of-range indices past `decode_batch`'s bounds check.
- `BatchDecoder` gained owning raw pointers freed in a new destructor without deleting the implicit copy operations (double free).
- The scaler and scratch buffer shared one destination-geometry field, so a caller-supplied `sws_ctx` could have left a stale context scaling into a differently sized buffer.
- Scaler cache keys are now cleared before configuring, so a `sws_setColorspaceDetails` failure cannot leave a half-built context reachable via a stale-key cache hit.
- The `BatchDecoder` constructor rejects channel counts other than 3: the RGB24 copy writes `height * width * 3` bytes per position, so a 1-channel config (grayscale, rejected upstream) would have overflowed the output tensor instead of just producing wrong pixels.
- `CUDAARCHS=90 pip install .` was silently discarded once the guard moved ahead of `enable_language`; it is now honoured. Build trees predating this change still carry a single-arch cache entry, which now warns.
- Comments and the debug log line still described the batch context as slice-only.
- Documented the real GPU floor for the published CUDA 13 wheels (compute capability 7.5+).

## Not fixed here (pre-existing, out of scope)

- `Decoder::seek()` calls `startDecodingThread()` with no `syncMode_` guard, so a seek in sync mode (the default CPU path) spawns a producer that races the sync consumer on the same codec context.
- `decode_batch` skips its producer-stop block entirely in sync mode, so `BatchDecoder`'s seek repositions the shared `formatCtx` without resetting sync feed state or flushing `codecCtx` — iteration resumed after a batch can return wrong frames.
- Concurrent `decode_batch` calls on one reader race on `formatCtx`/`batchCodecCtx_`, frame threads or not.
- The NVDEC `reconfigure` override duplicates the base implementation by hand instead of calling it, so base-class resets do not reach it.

## Testing

`248 passed, 1 skipped, 2 xfailed, 1 xpassed` on the full suite (Python 3.14, torch 2.13, CUDA build). `tests/test_color_difference.py` fails to import with a pre-existing `ModuleNotFoundError: No module named 'utils'`, unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
